### PR TITLE
Fix typos in overmap description

### DIFF
--- a/FeatureList.md
+++ b/FeatureList.md
@@ -19,7 +19,7 @@ Ranged and melee combat are currently implemented.
 ![Catax_inventory](Media/Dimensionfall_inventory.png)
 
 ### Overmap
-The game will create an infinite map to explore. The world is devided by regions, each having their own oppertunities and challenges. A marker will indicate your current location.
+The game will create an infinite map to explore. The world is divided by regions, each having their own opportunities and challenges. A marker will indicate your current location.
 
 ![Catax_overmap](Media/Dimensionfall_overmap.png)
 


### PR DESCRIPTION
## Summary
- correct typos in `FeatureList.md` around the Overmap section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f665cd43c8325a5267357595ec0f5