### PR TITLE
Add sound properties to tile classes

### DIFF
--- a/Scripts/Gamedata/DTile.gd
+++ b/Scripts/Gamedata/DTile.gd
@@ -27,27 +27,33 @@ var shape: String
 var sprite: Texture
 var spriteid: String
 var categories: Array
+var sound_category: String = ""
+var sound_volume: int = 100
 var parent: DTiles
 
 # Constructor to initialize tile properties from a dictionary
 func _init(data: Dictionary, myparent: DTiles):
-	parent = myparent
-	id = data.get("id", "")
-	name = data.get("name", "")
-	description = data.get("description", "")
-	shape = data.get("shape", "")
-	spriteid = data.get("sprite", "")
-	categories = data.get("categories", [])
+        parent = myparent
+        id = data.get("id", "")
+        name = data.get("name", "")
+        description = data.get("description", "")
+        shape = data.get("shape", "")
+        spriteid = data.get("sprite", "")
+        categories = data.get("categories", [])
+        sound_category = data.get("sound_category", "")
+        sound_volume = data.get("sound_volume", 100)
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
-	var data: Dictionary = {
-		"id": id,
-		"name": name,
-		"description": description,
-		"sprite": spriteid,
-		"categories": categories
-	}
+        var data: Dictionary = {
+                "id": id,
+                "name": name,
+                "description": description,
+                "sprite": spriteid,
+                "categories": categories,
+                "sound_category": sound_category,
+                "sound_volume": sound_volume
+        }
 	
 	if shape and not shape == "":
 		data["shape"] = shape

--- a/Scripts/Runtimedata/RTile.gd
+++ b/Scripts/Runtimedata/RTile.gd
@@ -31,14 +31,18 @@ var shape: String
 var spriteid: String
 var sprite: Texture
 var categories: Array = []
+var sound_category: String = ""
+var sound_volume: int = 100
 var parent: RTiles
 
 # Constructor to initialize tile properties from a dictionary
 # data: the data as loaded from json
 # myparent: The list containing all tiles for this mod
 func _init(myparent: RTiles, newid: String):
-	parent = myparent
-	id = newid
+        parent = myparent
+        id = newid
+        sound_category = ""
+        sound_volume = 100
 
 # Overwrite this tile's properties using a DTile
 func overwrite_from_dtile(dtile: DTile) -> void:
@@ -48,18 +52,22 @@ func overwrite_from_dtile(dtile: DTile) -> void:
 	description = dtile.description
 	shape = dtile.shape
 	spriteid = dtile.spriteid
-	sprite = dtile.sprite
-	categories = dtile.categories.duplicate(true)
+        sprite = dtile.sprite
+        categories = dtile.categories.duplicate(true)
+        sound_category = dtile.sound_category
+        sound_volume = dtile.sound_volume
 
 # Get data function to return a dictionary with all properties
 func get_data() -> Dictionary:
-	var data: Dictionary = {
-		"id": id,
-		"name": name,
-		"description": description,
-		"sprite": spriteid,
-		"categories": categories
-	}
+        var data: Dictionary = {
+                "id": id,
+                "name": name,
+                "description": description,
+                "sprite": spriteid,
+                "categories": categories,
+                "sound_category": sound_category,
+                "sound_volume": sound_volume
+        }
 	if shape and not shape == "":
 		data["shape"] = shape
 	return data


### PR DESCRIPTION
## Summary
- store sound settings in `DTile` data
- persist sound settings when reading/writing JSON
- keep runtime `RTile` objects aware of sound settings

## Testing
- `godot --headless -s CataX/addons/gut/gut_cmdln.gd -d -gdir=CataX/Tests/Unit -gexit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f790e276483258cfd67f32f8198bc