### PR TITLE
Fix tooltip typo in TerrainTileEditor

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/TerrainTileEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/TerrainTileEditor.tscn
@@ -129,7 +129,7 @@ text = "Cube"
 
 [node name="SlopeShapeCheckBox" type="CheckBox" parent="VBoxContainer/FormGrid/ShapeButtonContainer"]
 layout_mode = 2
-tooltip_text = "Select this if this terrain should be represented by a slope. Tipically ised for stairs or ramps. The player can go one level up if approached from the right angle."
+tooltip_text = "Select this if this terrain should be represented by a slope. Typically used for stairs or ramps. The player can go one level up if approached from the right angle."
 text = "Slope"
 
 [node name="Sprite_selector" parent="." instance=ExtResource("5_5ngda")]


### PR DESCRIPTION
## Summary
- fix a typo in `SlopeShapeCheckBox` tooltip in TerrainTileEditor scene

## Testing
- `godot3-server --headless --no-window --quit --path . -s addons/gut/gut_cmdln.gd -gdir=res://Tests/Unit -ginclude_subdirs -gexit` *(fails: Can't open project at '/workspace/CataX/project.godot', its config_version (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_6841f00a2f4c83259f90b612924bf8b8