### PR TITLE
Fix typos in editor script comments

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
@@ -79,7 +79,7 @@ func _on_sprite_selector_sprite_selected_ok(clicked_sprite) -> void:
 	PathTextLabel.text = slotTexture.resource_path.get_file()
 
 
-# Set the drop funcitons on the required item and item progression controls
+# Set the drop functions on the required item and item progression controls
 # This enables them to receive drop data
 func set_drop_functions():
 	starting_item_text_edit.drop_function = item_drop

--- a/Scripts/ItemCraftEditor.gd
+++ b/Scripts/ItemCraftEditor.gd
@@ -316,7 +316,7 @@ func can_skill_drop(dropped_data: Dictionary):
 	return true
 
 
-# Set the drop funcitons on the required skill and skill progression controls
+# Set the drop functions on the required skill and skill progression controls
 # This enables them to receive drop data
 func set_drop_functions():
 	required_skill_text_edit.drop_function = skill_drop.bind(required_skill_text_edit)

--- a/Scripts/ItemMeleeEditor.gd
+++ b/Scripts/ItemMeleeEditor.gd
@@ -75,7 +75,7 @@ func can_skill_drop(dropped_data: Dictionary):
 	return true
 
 
-# Set the drop funcitons on the required skill and skill progression controls
+# Set the drop functions on the required skill and skill progression controls
 # This enables them to receive drop data
 func set_drop_functions():
 	UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -119,7 +119,7 @@ func can_skill_drop(dropped_data: Dictionary):
 	return true
 
 
-# Set the drop funcitons on the required skill and skill progression controls
+# Set the drop functions on the required skill and skill progression controls
 # This enables them to receive drop data
 func set_drop_functions():
 	UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)


### PR DESCRIPTION
## Summary
- fix typo in drop function comments in editor scripts

## Testing
- `godot --headless -s addons/gut/gut_cmdln.gd -gdir=Tests/Unit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6715f088325ab439fb075980bc0