### PR TITLE
Clarify OvermapTile comment

### DIFF
--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -18,9 +18,9 @@ var map_cell:
 
 signal tile_clicked(clicked_tile: Control)
 
-# Handle mouse input to emit the tile_clicked signal
+# Emit tile_clicked when the mouse enters the tile
 func _on_texture_rect_mouse_entered():
-	tile_clicked.emit(self)
+       tile_clicked.emit(self)
 
 func _on_texture_rect_gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:


### PR DESCRIPTION
## Summary
- clarify the comment describing tile click emission in `OvermapTile.gd`

## Testing
- `godot4 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6d551288325ae71c79d8c9dc1e5