### PR TITLE
Fix typos in GDScript comments

### DIFF
--- a/Scenes/ContentManager/Custom_Widgets/Scripts/Scrolling_Flow_Container.gd
+++ b/Scenes/ContentManager/Custom_Widgets/Scripts/Scrolling_Flow_Container.gd
@@ -1,7 +1,7 @@
 extends Control
 
 #This script belongs to the Scrolling_Flow_Container scene
-#It shows a flowcontianer in a scrollcontainer and optionally a collapse button
+#It shows a flow container in a scrollcontainer and optionally a collapse button
 #Once instanced, set the collapse button text to the text you want
 #If you set the header as empty it will hide the collapse button
 

--- a/Scripts/general.gd
+++ b/Scripts/general.gd
@@ -20,7 +20,7 @@ func _ready():
 
 # Function to start an action
 # Usage example: 
-	# This example will call the 'reload_weapon" functoin in self after the timer is complete
+        # This example will call the 'reload_weapon" function in self after the timer is complete
 	# var reload_callable = Callable(self, "reload_weapon").bind(item, specific_magazine)
 	# General.start_action(reload_time, reload_callable)
 # Usage example using an inline callable:


### PR DESCRIPTION
## Summary
- fix typo in usage example in `general.gd`
- fix typo in `Scrolling_Flow_Container.gd`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c7fc482c832597eb0b06ddba4bcd