### PR TITLE
Fix input toggle null check

### DIFF
--- a/Scripts/main_window_contianer.gd
+++ b/Scripts/main_window_contianer.gd
@@ -30,8 +30,10 @@ func _ready():
 func _on_close_button_pressed():
 	visible = false
 
-func _input(event):
+	func _input(event):
 	# Check if we need to hide based on what input action the child window uses
-	var myinputaction: String = body_scene_instance.input_action
+	var myinputaction := ""
+	if body_scene_instance:
+		myinputaction = body_scene_instance.input_action
 	if myinputaction != "" and event.is_action_pressed(myinputaction):
 		visible = not visible


### PR DESCRIPTION
## Summary
- handle null body scene instance in the window container

## Testing
- `godot3 --headless -s addons/gut/gut_cmdln.gd -gdir=res://Tests/Unit -gexit` *(fails: Can't open project at '/workspace/CataX/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_6845c7f65dd88325a82a83c45b06bb83