### PR TITLE
Fix typo in map_cell comment

### DIFF
--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -33,7 +33,7 @@ enum Region {
 class map_cell:
 	# Enum for revealed states
 	enum RevealedState {
-		HIDDEN,  # Default state. The cell has been instanced onto a grid, nothimg more
+               HIDDEN,  # Default state. The cell has been instanced onto a grid, nothing more
 		REVEALED, # the map has been revealed on the overmap when the player got close enough
 		EXPLORED, # the map has been loaded as a chunk in the player's proximity at least once
 		VISITED # the player has entered the boundary of the map's coordinates


### PR DESCRIPTION
## Summary
- fix minor typo in `map_cell` comment for `RevealedState.HIDDEN`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68643eaaec888325a77743b0433ae379