### PR TITLE
Remove unused building menu flag

### DIFF
--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -1,7 +1,6 @@
 extends GridContainer
 
 
-var is_building_menu_open = false
 @export var construction_option_button: OptionButton = null
 
 # Called when the node enters the scene tree for the first time.


### PR DESCRIPTION
## Summary
- clean up `Scripts/BuildingMenu.gd` by removing `is_building_menu_open`

## Testing
- `godot -s addons/gut/gut_cmdln.gd -gdir=res://Tests/Unit -gexit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865718c67208325afddba9ee0c17d56