### PR TITLE
Fix refrigerator item group id

### DIFF
--- a/Mods/Dimensionfall/Furniture/Furniture.json
+++ b/Mods/Dimensionfall/Furniture/Furniture.json
@@ -281,7 +281,7 @@
 	},
 	{
 		"Function": {
-			"container_group": "refridgerator",
+			"container_group": "refrigerator",
 			"is_container": true
 		},
 		"categories": [
@@ -655,7 +655,7 @@
 	},
 	{
 		"Function": {
-			"container_group": "refridgerator",
+			"container_group": "refrigerator",
 			"is_container": true
 		},
 		"categories": [

--- a/Mods/Dimensionfall/Itemgroups/Itemgroups.json
+++ b/Mods/Dimensionfall/Itemgroups/Itemgroups.json
@@ -236,8 +236,8 @@
 		"use_sprite": false
 	},
 	{
-		"description": "Items you can find in a refridgerator in an urban home",
-		"id": "refridgerator",
+		"description": "Items you can find in a refrigerator in an urban home",
+		"id": "refrigerator",
 		"items": [
 			{
 				"id": "bottle_plastic_water",
@@ -349,7 +349,7 @@
 			}
 		],
 		"mode": "Collection",
-		"name": "Refridgerator",
+		"name": "Refrigerator",
 		"sprite": "bottle_empty_32.png",
 		"use_sprite": false
 	},

--- a/Mods/Dimensionfall/Itemgroups/references.json
+++ b/Mods/Dimensionfall/Itemgroups/references.json
@@ -163,7 +163,7 @@
 			"military_bunker"
 		]
 	},
-	"refridgerator": {
+	"refrigerator": {
 		"maps": [
 			"store_groceries"
 		]

--- a/Mods/Dimensionfall/Items/references.json
+++ b/Mods/Dimensionfall/Items/references.json
@@ -6,7 +6,7 @@
 	},
 	"apple": {
 		"itemgroups": [
-			"refridgerator",
+			"refrigerator",
 			"starting_items"
 		]
 	},
@@ -18,7 +18,7 @@
 	},
 	"bag_bacon": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"bandage_basic": {
@@ -111,7 +111,7 @@
 	},
 	"bottle_plastic_water": {
 		"itemgroups": [
-			"refridgerator",
+			"refrigerator",
 			"kitchen_cupboard",
 			"cabinet_general",
 			"vending_machine_drinks",
@@ -124,7 +124,7 @@
 	},
 	"bottle_yogurt": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"branch": {
@@ -159,12 +159,12 @@
 	},
 	"butter": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"can_beer": {
 		"itemgroups": [
-			"refridgerator",
+			"refrigerator",
 			"kitchen_cupboard",
 			"vending_machine_drinks",
 			"zombie_loot"
@@ -172,7 +172,7 @@
 	},
 	"can_energydrink": {
 		"itemgroups": [
-			"refridgerator",
+			"refrigerator",
 			"vending_machine_drinks",
 			"zombie_loot"
 		]
@@ -184,7 +184,7 @@
 	},
 	"can_soda": {
 		"itemgroups": [
-			"refridgerator",
+			"refrigerator",
 			"vending_machine_drinks",
 			"starting_items",
 			"zombie_loot",
@@ -201,7 +201,7 @@
 	},
 	"carrot": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"ceramic_fragments": {
@@ -211,7 +211,7 @@
 	},
 	"cheese": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"chocolate": {
@@ -277,7 +277,7 @@
 	},
 	"eggs": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"electrical_components": {
@@ -383,7 +383,7 @@
 	},
 	"kiwi": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"large_rock": {
@@ -402,7 +402,7 @@
 	},
 	"lettuce": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"log": {
@@ -630,7 +630,7 @@
 	},
 	"slice_of_pizza": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"small_rock": {
@@ -711,12 +711,12 @@
 	},
 	"tofu": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"tomato": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"transmitter": {
@@ -732,12 +732,12 @@
 	},
 	"uncooked_meat": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"vacuum_sealed_fish": {
 		"itemgroups": [
-			"refridgerator"
+			"refrigerator"
 		]
 	},
 	"vest_ballistic": {

--- a/Mods/Dimensionfall/Maps/store_groceries.json
+++ b/Mods/Dimensionfall/Maps/store_groceries.json
@@ -1144,7 +1144,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -1161,7 +1161,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -1192,7 +1192,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -1209,7 +1209,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -1538,7 +1538,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -1555,7 +1555,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -1586,7 +1586,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -1603,7 +1603,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -1913,7 +1913,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -1930,7 +1930,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -1961,7 +1961,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -1978,7 +1978,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -2192,7 +2192,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -2209,7 +2209,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -2240,7 +2240,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -2257,7 +2257,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -2562,7 +2562,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -2579,7 +2579,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},
@@ -2610,7 +2610,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 90.0
 				},
@@ -2627,7 +2627,7 @@
 				"furniture": {
 					"id": "display_case",
 					"itemgroups": [
-						"refridgerator"
+						"refrigerator"
 					],
 					"rotation": 270.0
 				},

--- a/Scripts/Gamedata/DItems.gd
+++ b/Scripts/Gamedata/DItems.gd
@@ -130,7 +130,7 @@ func remove_reference(item_id: String) -> void:
 # The return value might look like this:
 #{
 #	"itemgroups": [
-#		"refridgerator",
+#		"refrigerator",
 #		"starting_items"
 #	]
 #}


### PR DESCRIPTION
## Summary
- fix the misspelled `refridgerator` item group id
- update references in items, furniture, and maps
- adjust related comment in gameplay script
- ensure Itemgroups.json uses tabs for indentation

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865710d1c10832580513d50e040eb21