### PR TITLE
Fix null sprites in Overmap

### DIFF
--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -10,10 +10,17 @@ var map_cell:
 	set(cell):
 		map_cell = cell
 		if map_cell and map_cell.is_revealed():
-			set_texture(map_cell.get_sprite())  # Set the texture if revealed
-			set_texture_rotation(map_cell.rotation, Vector2(16, 16))  # Apply the rotation
+			# Grab sprite from runtime map; could be null
+			var tex: Texture = map_cell.get_sprite()
+			if tex:
+				set_texture(tex)
+				# Apply the cell's rotation
+				set_texture_rotation(map_cell.rotation, Vector2(16, 16))
+			else:
+				# Use default texture when sprite missing
+				set_texture(null)
 		else:
-			set_texture(null)  # Clear the texture if not revealed
+			set_texture(null)	# Clear the texture if not revealed
 
 
 signal tile_clicked(clicked_tile: Control)

--- a/Scripts/OvermapGrid.gd
+++ b/Scripts/OvermapGrid.gd
@@ -74,7 +74,10 @@ class map_cell:
 		rotation = newdata.get("rotation", 0)
 
 	func get_sprite() -> Texture:
-		return rmap.sprite
+		if rmap:
+			return rmap.sprite
+		# rmap can be null if the map hasn't been instantiated
+		return null
 	
 	# Function to return formatted information about the map cell
 	func get_info_string() -> String:


### PR DESCRIPTION
## Summary
- guard against missing RMap sprite on the overmap grid
- handle null sprite case when assigning overmap tile textures

## Testing
- `godot4 --headless -s addons/gut/gut_cmdln.gd -gdir=Tests/Unit -ginclude_subdirs -gexit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68657144e6b0832589d3336d2badfa75