### PR TITLE
Fix OvermapTile mouse filter reset

### DIFF
--- a/Scenes/Overmap/Scripts/OvermapTile.gd
+++ b/Scenes/Overmap/Scripts/OvermapTile.gd
@@ -53,6 +53,10 @@ func set_clickable(clickable: bool):
 	if not clickable:
 		mouse_filter = MOUSE_FILTER_IGNORE
 		$TextureRect.mouse_filter = MOUSE_FILTER_IGNORE
+	else:
+		# Reset filters so tile is interactive again
+		mouse_filter = MOUSE_FILTER_STOP
+		$TextureRect.mouse_filter = MOUSE_FILTER_STOP
 
 # Show or hide the text on the tile
 func set_text_visible(isvisible: bool):


### PR DESCRIPTION
## Summary
- reset mouse filters on OvermapTile when enabled
- use tabs for indentation and add explanation comment

## Testing
- `godot3 --headless -s addons/gut/gut_cmdln.gd -d -gdir=res://Tests/Unit -gexit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865712aeab48325acb817bbb50fff4c