### PR TITLE
Add filter line edit to content list

### DIFF
--- a/Scenes/ContentManager/Scripts/content_list.gd
+++ b/Scenes/ContentManager/Scripts/content_list.gd
@@ -12,6 +12,7 @@ extends Control
 @export var popup_textedit: TextEdit = null
 @export var to_mod_h_box_container: HBoxContainer = null
 @export var mod_option_button: OptionButton = null
+@export var search_line: LineEdit = null
 
 
 signal item_activated(type: DMod.ContentType, itemID: String, list: Control)
@@ -57,6 +58,7 @@ func _ready():
 
 	# Other existing setup for the contentItems drag forwarding
 	contentItems.set_drag_forwarding(_create_drag_data, Callable(), Callable())
+	search_line.text_changed.connect(_on_search_changed)
 
 
 # This function adds items to the content list based on the provided path
@@ -243,6 +245,13 @@ func _on_content_items_gui_input(event):
 
 func _on_content_items_mouse_entered():
 	mouse_button_is_pressed = false
+
+	func _on_search_changed(new_text: String) -> void:
+	var query := new_text.to_lower()
+		for i in range(contentItems.item_count):
+		var item_text := contentItems.get_item_text(i).to_lower()
+		var match := query == "" or item_text.find(query) != -1
+		contentItems.set_item_hidden(i, !match)
 
 
 func save_collapse_state():

--- a/Scenes/ContentManager/content_list.tscn
+++ b/Scenes/ContentManager/content_list.tscn
@@ -20,6 +20,7 @@ pupup_ID = NodePath("ID_Input")
 popup_textedit = NodePath("ID_Input/VBoxContainer/IdTextEdit")
 to_mod_h_box_container = NodePath("ID_Input/VBoxContainer/ToModHBoxContainer")
 mod_option_button = NodePath("ID_Input/VBoxContainer/ToModHBoxContainer/ModOptionButton")
+search_line = NodePath("Content/SearchLine")
 
 [node name="Content" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -63,6 +64,10 @@ size_flags_stretch_ratio = 0.15
 tooltip_text = "Delete item"
 theme_override_font_sizes/font_size = 16
 text = "-"
+
+[node name="SearchLine" type="LineEdit" parent="Content"]
+layout_mode = 2
+placeholder_text = "Search..."
 
 [node name="ContentItems" type="ItemList" parent="Content"]
 custom_minimum_size = Vector2(200, 30)


### PR DESCRIPTION
## Summary
- add a `LineEdit` above the list of items in content_list.tscn
- expose the new node in `content_list.gd` and connect its signal
- implement `_on_search_changed` to hide items that do not match the query

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866efaac0e48325af3d3a879c47ef3d