### PR TITLE
Update context menu options

### DIFF
--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -83,10 +83,49 @@ func _ready():
 
 # Function to show context menu at specified position
 func show_context_menu(myposition: Vector2):
+	_update_context_menu_options(get_selected_inventory_items())
 	# Create a small Rect2i around the position
 	# We need this because the popup function requires it
 	var popup_rect = Rect2i(int(myposition.x), int(myposition.y), 1, 1)
 	context_menu.popup(popup_rect)
+
+# Updates the enabled/disabled state of the context menu based on the selected items
+func _update_context_menu_options(items: Array[InventoryItem]) -> void:
+	for i in range(context_menu.get_item_count()):
+	        context_menu.set_item_disabled(i, false)
+
+	var can_reload: bool = true
+	var can_unload: bool = true
+	var can_equip: bool = true
+	var can_use: bool = true
+
+	for item in items:
+	        if not _is_reloadable(item):
+	                can_reload = false
+	        if not _can_unload(item):
+	                can_unload = false
+	        if not _is_equippable(item):
+	                can_equip = false
+	        if not _is_usable(item):
+	                can_use = false
+
+	context_menu.set_item_disabled(0, !can_equip)
+	context_menu.set_item_disabled(1, !can_equip)
+	context_menu.set_item_disabled(2, !can_reload)
+	context_menu.set_item_disabled(3, !can_unload)
+	context_menu.set_item_disabled(4, !can_use)
+
+func _is_reloadable(item: InventoryItem) -> bool:
+	return item.get_property("Ranged") != null or item.get_property("Magazine") != null
+
+func _can_unload(item: InventoryItem) -> bool:
+	return item.get_property("Ranged") != null
+
+func _is_equippable(item: InventoryItem) -> bool:
+	return item.get_property("Ranged") != null or item.get_property("Melee") != null or item.get_property("Magazine") != null or item.get_property("Tool") != null
+
+func _is_usable(item: InventoryItem) -> bool:
+	return item.get_property("Food") != null or item.get_property("Medical") != null
 
 
 # Handle context menu item selection

--- a/Scripts/CtrlInventoryStackedCustom.gd
+++ b/Scripts/CtrlInventoryStackedCustom.gd
@@ -92,7 +92,7 @@ func show_context_menu(myposition: Vector2):
 # Updates the enabled/disabled state of the context menu based on the selected items
 func _update_context_menu_options(items: Array[InventoryItem]) -> void:
 	for i in range(context_menu.get_item_count()):
-	        context_menu.set_item_disabled(i, false)
+		context_menu.set_item_disabled(i, false)
 
 	var can_reload: bool = true
 	var can_unload: bool = true
@@ -100,14 +100,14 @@ func _update_context_menu_options(items: Array[InventoryItem]) -> void:
 	var can_use: bool = true
 
 	for item in items:
-	        if not _is_reloadable(item):
-	                can_reload = false
-	        if not _can_unload(item):
-	                can_unload = false
-	        if not _is_equippable(item):
-	                can_equip = false
-	        if not _is_usable(item):
-	                can_use = false
+		if not _is_reloadable(item):
+			can_reload = false
+		if not _can_unload(item):
+			can_unload = false
+		if not _is_equippable(item):
+			can_equip = false
+		if not _is_usable(item):
+			can_use = false
 
 	context_menu.set_item_disabled(0, !can_equip)
 	context_menu.set_item_disabled(1, !can_equip)


### PR DESCRIPTION
## Summary
- update context menu when showing popup
- disable context actions based on selected item properties
- add helper checks for equip, reload, unload and use
- convert inventory script indentation to tabs

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d3d1ce588325b60c4bd8fb8e97ed