### PR TITLE
Add unsaved changes confirmation

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/Scripts/AttacksEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/AttacksEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one Attack
 # It expects to save the data to a JSON file
@@ -43,6 +47,11 @@ var dattack: DAttack = null:
 
 # Forward drag-and-drop functionality to the attributesGridContainer
 func _ready() -> void:
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dattack.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	any_of_attributes_grid_container.set_drag_forwarding(Callable(), _can_drop_attribute_data, _drop_any_of_attribute_data)
 	all_of_attributes_grid_container.set_drag_forwarding(Callable(), _can_drop_attribute_data, _drop_all_of_attribute_data)
 
@@ -85,8 +94,10 @@ func load_attack_data() -> void:
 	_toggle_ranged_controls(dattack.type == "ranged")  # Update UI based on type
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in the DAttack instance

--- a/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/FurnitureEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is for editing a single piece of furniture.
 # It loads and saves data to a JSON file containing furniture data for a mod.
 # Provide the name of the furniture data file and an ID to load.
@@ -89,6 +93,11 @@ var dfurniture: DFurniture:
 
 
 func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dfurniture.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	# For properly using the tab key to switch elements
 	control_elements = [furniture_image_display,name_edit,description_edit]
 	#data_changed.connect(dfurniture.parent.on_data_changed)
@@ -200,8 +209,10 @@ func select_option_by_string(option_button: OptionButton, option_string: String)
 
 
 #The editor is closed, destroy the instance
-#TODO: Check for unsaved changes
 func _on_close_button_button_up():
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free.call_deferred()
 
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/ItemgroupEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one itemgroup
 # It expects to save the data to a JSON file that contains all itemgroup data from a mod
@@ -37,6 +41,11 @@ var ditemgroup: DItemgroup = null:
 
 
 func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): ditemgroup.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	control_elements = [itemgroupImageDisplay,NameTextEdit,DescriptionTextEdit]
 	modeOptionButton.add_item("Collection")
 	modeOptionButton.add_item("Distribution")
@@ -160,8 +169,10 @@ func select_option_by_string(option_button: OptionButton, option_string: String)
 
 
 #The editor is closed, destroy the instance
-#TODO: Check for unsaved changes
 func _on_close_button_button_up():
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one mob (friend and foe)
 # It expects to save the data to a DMob instance that contains all data from a mob
@@ -46,6 +50,11 @@ var dmob: DMob:
 
 # Forward drag-and-drop functionality to the attributesGridContainer
 func _ready() -> void:
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dmob.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	attacks_grid_container.set_drag_forwarding(Callable(), _can_drop_attack_data, _drop_attack_data)
 
 
@@ -98,8 +107,10 @@ func load_mob_data() -> void:
 
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in the DMob instance

--- a/Scenes/ContentManager/Custom_Editors/Scripts/MobgroupsEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/MobgroupsEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one Mobgroup
 # It expects to save the data to a JSON file
@@ -35,6 +39,11 @@ var dmobgroup: DMobgroup = null:
 
 # Forward drag-and-drop functionality to the attributesGridContainer
 func _ready() -> void:
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dmobgroup.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	mob_list.set_drag_forwarding(Callable(), _can_drop_mob_data, _drop_mob_data)
 
 
@@ -54,8 +63,10 @@ func load_mobgroup_data() -> void:
 	references_editor.reference_data = myreferences
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in the DMobgroup instance

--- a/Scenes/ContentManager/Custom_Editors/Scripts/OvermapAreaEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/OvermapAreaEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one DOvermapArea
 # It expects to save the data to a JSON file
@@ -110,6 +114,13 @@ var dovermaparea: DOvermaparea = null:
 		load_overmaparea_data()
 		olddata = DOvermaparea.new(dovermaparea.get_data().duplicate(true), null)
 
+func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dovermaparea.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
+
 
 # This function updates the form based on the DOvermaparea that has been loaded
 func load_overmaparea_data() -> void:
@@ -148,8 +159,10 @@ func load_overmaparea_data() -> void:
 
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/PlayerAttributeEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/PlayerAttributeEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one playerattribute
 # It expects to save the data to a DPlayerAttribute instance that contains all data from a attribute
@@ -46,6 +50,11 @@ var dplayerattribute: DPlayerAttribute:
 
 
 func _ready() -> void:
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dplayerattribute.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	# Set drag forwarding for the drain_attribute_grid_container
 	drain_attribute_grid_container.set_drag_forwarding(Callable(), _can_drop_attribute_data, _drop_attribute_data)
 	
@@ -117,8 +126,10 @@ func process_fixed_mode() -> void:
 
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 

--- a/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/QuestEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one quest
 # It expects to save the data to a JSON file
@@ -44,6 +48,11 @@ var dquest: DQuest = null:
 		olddata = DQuest.new(dquest.get_data().duplicate(true), null)
 
 func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dquest.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	ok_button.pressed.connect(_on_ok_button_pressed)
 	cancel_button.pressed.connect(_on_cancel_button_pressed)
 
@@ -62,8 +71,10 @@ func _ready():
 	}
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function updates the form based on the DQuest that has been loaded

--- a/Scenes/ContentManager/Custom_Editors/Scripts/SkillsEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/SkillsEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one Skill
 # It expects to save the data to a JSON file
@@ -28,6 +32,13 @@ var dskill: DSkill = null:
 		skillSelector.sprites_collection = dskill.parent.sprites
 		olddata = DSkill.new(dskill.get_data().duplicate(true), null)
 
+func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dskill.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
+
 # This function updates the form based on the DSkill that has been loaded
 func load_skill_data() -> void:
 	if skillImageDisplay != null and dskill.spriteid != "":
@@ -41,8 +52,10 @@ func load_skill_data() -> void:
 		DescriptionTextEdit.text = dskill.description
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in the DSkill instance

--- a/Scenes/ContentManager/Custom_Editors/Scripts/StatsEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/StatsEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one Stat
 # It expects to save the data to a JSON file
@@ -28,6 +32,13 @@ var dstat: DStat = null:
 		statSelector.sprites_collection = dstat.parent.sprites
 		olddata = DStat.new(dstat.get_data().duplicate(true), dstat.parent)
 
+func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dstat.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
+
 
 # This function updates the form based on the DStat that has been loaded
 func load_stat_data() -> void:
@@ -42,8 +53,10 @@ func load_stat_data() -> void:
 		DescriptionTextEdit.text = dstat.description
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in the DStat instance

--- a/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/TerrainTileEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one tile
 # It expects to save the data to a JSON file that contains all tile data from a mod
@@ -33,6 +37,11 @@ var dtile: DTile = null:
 
 
 func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dtile.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	control_elements = [
 		tileImageDisplay,
 		NameTextEdit,
@@ -93,8 +102,10 @@ func select_option_by_string(option_button: OptionButton, option_string: String)
 	print_debug("No matching option found for the string: " + option_string)
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up():
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in dtile

--- a/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/Scripts/WearableslotEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 #This scene is intended to be used inside the content editor
 #It is supposed to edit exactly one Equipmentslot
 #It expects to save the data to a JSON file
@@ -32,6 +36,11 @@ var dwearableslot: DWearableSlot = null:
 
 
 func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dwearableslot.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	set_drop_functions()
 
 # This function updates the form based on the DWearableSlot that has been loaded
@@ -48,8 +57,10 @@ func load_slot_data() -> void:
 	starting_item_text_edit.set_text(dwearableslot.starting_item)
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in the DWearableSlot instance

--- a/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditor.gd
+++ b/Scenes/ContentManager/Custom_Editors/TacticalMapEditor/Scripts/TacticalMapEditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 
 @export var tileGrid: GridContainer = null
 @export var mapwidthTextEdit: SpinBox = null
@@ -34,6 +38,11 @@ var currentMap: DTacticalmap:
 
 # In tacticalmapeditor.gd
 func _ready() -> void:
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): currentMap.get_data(),
+		func(): oldmap.get_data(),
+		Callable(self, "_close_editor"))
 	# For properly using the tab key to switch elements
 	control_elements = [mapwidthTextEdit,mapheightTextEdit]
 	setPanWindowSize()
@@ -81,8 +90,10 @@ func setPanWindowSize():
 
 
 #The editor is closed, destroy the instance
-#TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 

--- a/Scenes/ContentManager/Custom_Editors/mobfactions_editor.gd
+++ b/Scenes/ContentManager/Custom_Editors/mobfactions_editor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 # This scene is intended to be used inside the content editor
 # It is supposed to edit exactly one Mobfaction
 # It expects to save the data to a JSON file
@@ -51,6 +55,11 @@ var dmobfaction: DMobfaction = null:
 
 
 func _ready() -> void:
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): dmobfaction.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	if friendly_grid_container:
 		friendly_grid_container.set_drag_forwarding(Callable(), _can_entity_drop.bind("friendly"), _entity_drop.bind("friendly"))
 	if neutral_grid_container:
@@ -60,8 +69,10 @@ func _ready() -> void:
 
 
 # The editor is closed, destroy the instance
-# TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 func load_mobfaction_data() -> void:

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd
@@ -1,5 +1,9 @@
 extends Control
 
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
+
 @export var panWindow: Control = null
 @export var mapScrollWindow: ScrollContainer = null
 @export var gridContainer: ColorRect = null
@@ -41,6 +45,11 @@ var zoom_level: int = 20:
 
 
 func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): currentMap.get_data(),
+		func(): tileGrid.oldmap.get_data(),
+		Callable(self, "_close_editor"))
 	setPanWindowSize()
 	zoom_level = 20
 
@@ -82,8 +91,10 @@ func _on_tile_grid_zoom_level_changed(value):
 	zoom_level = value
 
 #The editor is closed, destroy the instance
-#TODO: Check for unsaved changes
 func _on_close_button_button_up():
+	_unsaved.request_close()
+
+func _close_editor():
 	# If the user has pressed the save button before closing the editor, the tileGrid.oldmap should
 	# contain the same data as currentMap, so it shouldn't make a difference
 	# If the user did not press the save button, we reset the map to what it was before the last save

--- a/Scripts/Helper/unsaved_changes_helper.gd
+++ b/Scripts/Helper/unsaved_changes_helper.gd
@@ -1,0 +1,40 @@
+extends Node
+class_name UnsavedChangesHelper
+
+var dialog := ConfirmationDialog.new()
+var _get_current_data : Callable
+var _get_original_data : Callable
+var _close_callback : Callable = func(): pass
+
+func _init():
+	dialog.dialog_text = "You have unsaved changes. Close without saving?"
+	dialog.ok_button_text = "Close"
+	dialog.get_cancel_button().text = "Cancel"
+	dialog.connect("confirmed", _on_confirmed)
+	dialog.connect("canceled", _on_canceled)
+	dialog.hide()
+
+func setup(parent: Node, get_current_data: Callable, get_original_data: Callable, close_callback: Callable) -> void:
+	_get_current_data = get_current_data
+	_get_original_data = get_original_data
+	_close_callback = close_callback
+	parent.add_child(dialog)
+
+func request_close() -> void:
+	if _has_unsaved_changes():
+		dialog.popup_centered()
+	else:
+		_close_callback.call()
+
+func _has_unsaved_changes() -> bool:
+	if _get_current_data.is_null() or _get_original_data.is_null():
+		return false
+	var current = _get_current_data.call()
+	var original = _get_original_data.call()
+	return JSON.stringify(current) != JSON.stringify(original)
+
+func _on_confirmed() -> void:
+	_close_callback.call()
+
+func _on_canceled() -> void:
+	pass

--- a/Scripts/ItemEditor.gd
+++ b/Scripts/ItemEditor.gd
@@ -3,6 +3,10 @@ extends Control
 #This scene is intended to be used inside the content editor
 #It is supposed to edit exactly one item
 #It expects to save the data to a DItem instance that contains all data from an item
+
+const UnsavedChangesHelper = preload("res://Scripts/Helper/unsaved_changes_helper.gd")
+
+@onready var _unsaved := UnsavedChangesHelper.new()
 #To load data, provide the DItem instance
 
 
@@ -51,6 +55,11 @@ var ditem: DItem = null:
 			olddata = DItem.new(ditem.get_data().duplicate(true), null)
 		
 func _ready():
+	add_child(_unsaved)
+	_unsaved.setup(self,
+		func(): ditem.get_data(),
+		func(): olddata.get_data(),
+		Callable(self, "_close_editor"))
 	refresh_tab_visibility()
 
 
@@ -93,8 +102,10 @@ func load_item_data() -> void:
 
 
 #The editor is closed, destroy the instance
-#TODO: Check for unsaved changes
 func _on_close_button_button_up() -> void:
+	_unsaved.request_close()
+
+func _close_editor():
 	queue_free()
 
 # This function takes all data from the form elements and stores them in the ditem


### PR DESCRIPTION
## Summary
- add `UnsavedChangesHelper` for reusable dirty-state checking
- warn on close in map editor
- warn on close in content editors
- switch indentation to tabs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866ef68bccc8325bdbe2e0316a1beb6