### PR TITLE
Rename LevelGenerator variable

### DIFF
--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -1,3 +1,4 @@
+class_name BuildManager
 extends Node3D
 
 @export var construction_ghost: MeshInstance3D
@@ -5,7 +6,7 @@ var is_building = false
 var construction_type: String = "block"
 var construction_choice: String = ""
 
-@export var LevelGenerator: Node3D
+@export var level_generator: Node3D
 @export var hud: NodePath
 
 func _ready():
@@ -50,7 +51,7 @@ func on_construction_clicked(construction_data: Dictionary):
 		print_debug("Construction type or choice is not set. Aborting.")
 		return
 
-	var chunk: Chunk = LevelGenerator.get_chunk_from_position(construction_data.pos)
+	var chunk: Chunk = level_generator.get_chunk_from_position(construction_data.pos)
 	if not chunk:
 		return
 

--- a/level_generation.tscn
+++ b/level_generation.tscn
@@ -50,10 +50,10 @@ sky_mode = 1
 [node name="LevelManager" type="Node3D" parent="TacticalMap"]
 script = ExtResource("2_gm6x7")
 
-[node name="BuildManager" type="Node3D" parent="TacticalMap" node_paths=PackedStringArray("construction_ghost", "LevelGenerator")]
+[node name="BuildManager" type="Node3D" parent="TacticalMap" node_paths=PackedStringArray("construction_ghost", "level_generator")]
 script = ExtResource("6_y7rk5")
 construction_ghost = NodePath("ConstructionGhost")
-LevelGenerator = NodePath("../LevelGenerator")
+level_generator = NodePath("../LevelGenerator")
 hud = NodePath("../../HUD")
 
 [node name="ConstructionGhost" type="MeshInstance3D" parent="TacticalMap/BuildManager" node_paths=PackedStringArray("player", "buildmanager", "construction_ghost_area_3d", "construction_ghost_collision_shape_3d")]


### PR DESCRIPTION
## Summary
- declare `BuildManager` class
- rename `LevelGenerator` property to `level_generator`
- update scene references
- fix chunk lookup line indentation

## Testing
- `godot --headless -s addons/gut/gut_cmdln.gd -d Tests/Unit -gexit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686811ce19088325b0ad7f00ad0072a7