### PR TITLE
Add ItemManager unit tests

### DIFF
--- a/Tests/Unit/test_item_manager.gd
+++ b/Tests/Unit/test_item_manager.gd
@@ -1,0 +1,50 @@
+extends GutTest
+
+var item_manager: ItemManager
+
+func before_all():
+	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
+	Runtimedata.reconstruct(custom_mods)
+	await get_tree().process_frame
+
+func before_each():
+	item_manager = preload("res://Scripts/item_manager.gd").new()
+	add_child(item_manager)
+	await get_tree().process_frame
+	item_manager.playerInventory = item_manager.initialize_inventory()
+
+func after_each():
+	if item_manager:
+	item_manager.queue_free()
+
+func after_all():
+	Runtimedata.reset()
+
+func _create_weapon() -> InventoryItem:
+	return item_manager.playerInventory.create_and_add_item("pistol_9mm")
+
+func _create_magazine(ammo: int) -> InventoryItem:
+	var mag = item_manager.playerInventory.create_and_add_item("pistol_magazine")
+	var props = mag.get_property("Magazine")
+	props["current_ammo"] = ammo
+	mag.set_property("Magazine", props)
+	return mag
+
+func test_find_compatible_magazine() -> void:
+	var gun = _create_weapon()
+	var _low = _create_magazine(5)
+	var high = _create_magazine(15)
+	assert_eq(item_manager.find_compatible_magazine(gun), high, "Should pick mag with most ammo")
+
+func test_reload_weapon_no_magazine() -> void:
+	var gun = _create_weapon()
+	assert_false(item_manager.reload_weapon(gun), "Reload should fail without magazine")
+
+func test_start_reload_inserts_magazine() -> void:
+	var gun = _create_weapon()
+	var mag = _create_magazine(10)
+	item_manager.start_reload(gun, 0.01, mag)
+	await wait_frames(5)
+	assert_eq(gun.get_property("current_magazine"), mag, "Magazine should be inserted")
+	assert_false(item_manager.playerInventory.has_item(mag), "Magazine should be removed from inventory")
+	assert_false(gun.get_property("is_reloading"), "Reload flag should reset")


### PR DESCRIPTION
## Summary
- add unit test for ItemManager's reloading helpers

## Testing
- `godot --headless -s addons/gut/gut_cmdln.gd -gdir=res://Tests/Unit -ginclude_subdirs -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682aae8a9483259ef83fef2dc32d50