### PR TITLE
Add DropEntityTextEdit unit test

### DIFF
--- a/Scenes/ContentManager/Custom_Widgets/Scripts/DropEntityTextEdit.gd
+++ b/Scenes/ContentManager/Custom_Widgets/Scripts/DropEntityTextEdit.gd
@@ -94,3 +94,17 @@ func enable() -> void:
 	is_disabled = false  # Reset the disabled flag
 	if button:  # Ensure button is valid before enabling
 		button.disabled = false
+
+
+# Setter for `content_types`. Validates and stores the array.
+func set_content_types(types: Array[DMod.ContentType]) -> void:
+	# Ensure we have an Array of the correct enum type
+	if typeof(types) != TYPE_ARRAY:
+		push_error("content_types must be an Array of DMod.ContentType")
+		return
+	for t in types:
+		if typeof(t) != TYPE_INT:
+			push_error("content_types contains a non-ContentType value: %s" % str(t))
+			return
+	# Store it
+	content_types = types.duplicate()

--- a/Tests/Unit/test_drop_entity_text_edit.gd
+++ b/Tests/Unit/test_drop_entity_text_edit.gd
@@ -1,0 +1,73 @@
+class_name TestDropEntityTextEdit
+extends GutTest
+
+var drop_scene: PackedScene = preload("res://Scenes/ContentManager/Custom_Widgets/DropEntityTextEdit.tscn")
+var drop_widget: HBoxContainer
+
+func before_all():
+	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
+	Runtimedata.reconstruct(custom_mods)
+	await get_tree().process_frame
+
+func before_each():
+	drop_widget = drop_scene.instantiate()
+	add_child(drop_widget)
+	drop_widget.content_types = [DMod.ContentType.WEARABLESLOTS, DMod.ContentType.PLAYERATTRIBUTES]
+	await get_tree().process_frame
+
+func after_each():
+	if drop_widget:
+		drop_widget.queue_free()
+
+func after_all():
+	Runtimedata.reset()
+
+func test_can_drop_valid_data() -> void:
+	var data := {
+		"id": "generic_test_wearable_slot",
+		"text": "Test wearable slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.WEARABLESLOTS
+	}
+	assert_true(drop_widget._can_drop_data(Vector2.ZERO, data))
+
+func test_can_drop_invalid_id() -> void:
+	var data := {
+		"id": "non_existing_slot",
+		"text": "Bad slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.WEARABLESLOTS
+	}
+	assert_false(drop_widget._can_drop_data(Vector2.ZERO, data))
+
+func test_can_drop_wrong_type() -> void:
+	var data := {
+		"id": "generic_test_wearable_slot",
+		"text": "Test wearable slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.MAPS
+	}
+	assert_false(drop_widget._can_drop_data(Vector2.ZERO, data))
+
+func test_drop_data_updates_state() -> void:
+	var data := {
+		"id": "generic_test_wearable_slot",
+		"text": "Test wearable slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.WEARABLESLOTS
+	}
+	assert_null(drop_widget.dropped_data)
+	drop_widget._drop_data(Vector2.ZERO, data)
+	assert_eq(drop_widget.dropped_data, data)
+	assert_eq(drop_widget.get_text(), "generic_test_wearable_slot")
+
+func test_drop_data_rejects_invalid() -> void:
+	var data := {
+		"id": "non_existing_slot",
+		"text": "Bad slot",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.WEARABLESLOTS
+	}
+	drop_widget._drop_data(Vector2.ZERO, data)
+	assert_null(drop_widget.dropped_data)
+	assert_eq(drop_widget.get_text(), "")

--- a/Tests/Unit/test_drop_entity_text_edit.gd
+++ b/Tests/Unit/test_drop_entity_text_edit.gd
@@ -12,7 +12,8 @@ func before_all():
 func before_each():
 	drop_widget = drop_scene.instantiate()
 	add_child(drop_widget)
-	drop_widget.content_types = [DMod.ContentType.WEARABLESLOTS, DMod.ContentType.PLAYERATTRIBUTES]
+	var mycontenttypes: Array[DMod.ContentType] = [DMod.ContentType.WEARABLESLOTS, DMod.ContentType.PLAYERATTRIBUTES]
+	drop_widget.set_content_types(mycontenttypes)
 	await get_tree().process_frame
 
 func after_each():
@@ -56,7 +57,7 @@ func test_drop_data_updates_state() -> void:
 		"mod_id": "Test",
 		"contentType": DMod.ContentType.WEARABLESLOTS
 	}
-	assert_null(drop_widget.dropped_data)
+	assert_true(drop_widget.dropped_data.is_empty())
 	drop_widget._drop_data(Vector2.ZERO, data)
 	assert_eq(drop_widget.dropped_data, data)
 	assert_eq(drop_widget.get_text(), "generic_test_wearable_slot")
@@ -69,5 +70,5 @@ func test_drop_data_rejects_invalid() -> void:
 		"contentType": DMod.ContentType.WEARABLESLOTS
 	}
 	drop_widget._drop_data(Vector2.ZERO, data)
-	assert_null(drop_widget.dropped_data)
+	assert_true(drop_widget.dropped_data.is_empty())
 	assert_eq(drop_widget.get_text(), "")

--- a/Tests/Unit/test_drop_entity_text_edit.gd.uid
+++ b/Tests/Unit/test_drop_entity_text_edit.gd.uid
@@ -1,0 +1,1 @@
+uid://ckpblpda0epu


### PR DESCRIPTION
## Summary
- add a new Gut test for DropEntityTextEdit covering `_can_drop_data` and `_drop_data`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682acb4f008325ab19c7de63dd41a8