### PR TITLE
Add accuracy stat drop support in ranged editor

### DIFF
--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://cibcfcysyj15" path="res://Scripts/ItemRangedEditor.gd" id="1_my1v7"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_crphu"]
 
-[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "AccuracyStatTextEdit")]
+[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "accuracy_stat_text_edit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -21,7 +21,7 @@ UsedSkillTextEdit = NodePath("Ranged/SkillHBoxContainer/UsedSkillTextEdit")
 skill_xp_spin_box = NodePath("Ranged/SkillHBoxContainer/SkillXPSpinBox")
 ReloadSpeedNumberBox = NodePath("Ranged/ReloadSpeedNumber")
 FiringSpeedNumberBox = NodePath("Ranged/FiringSpeedNumber")
-AccuracyStatTextEdit = NodePath("Ranged/AccuracyStatTextEdit")
+accuracy_stat_text_edit = NodePath("Ranged/AccuracyStatTextEdit")
 
 [node name="Ranged" type="GridContainer" parent="."]
 layout_mode = 1
@@ -156,5 +156,6 @@ text = "Accuracy Stat"
 
 [node name="AccuracyStatTextEdit" parent="Ranged" instance=ExtResource("2_crphu")]
 layout_mode = 2
+size_flags_vertical = 1
 tooltip_text = "The stat that improves accuracy for this weapon."
 myplaceholdertext = "Drop a stat from the list to the left"

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://cibcfcysyj15" path="res://Scripts/ItemRangedEditor.gd" id="1_my1v7"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_crphu"]
 
-[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox")]
+[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "AccuracyStatTextEdit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -21,6 +21,7 @@ UsedSkillTextEdit = NodePath("Ranged/SkillHBoxContainer/UsedSkillTextEdit")
 skill_xp_spin_box = NodePath("Ranged/SkillHBoxContainer/SkillXPSpinBox")
 ReloadSpeedNumberBox = NodePath("Ranged/ReloadSpeedNumber")
 FiringSpeedNumberBox = NodePath("Ranged/FiringSpeedNumber")
+AccuracyStatTextEdit = NodePath("Ranged/AccuracyStatTextEdit")
 
 [node name="Ranged" type="GridContainer" parent="."]
 layout_mode = 1
@@ -148,3 +149,12 @@ tooltip_text = "The delay between shots. A smaller number means firing more quic
 min_value = 0.01
 step = 0.01
 value = 0.25
+
+[node name="AccuracyStatLabel" type="Label" parent="Ranged"]
+layout_mode = 2
+text = "Accuracy Stat"
+
+[node name="AccuracyStatTextEdit" parent="Ranged" instance=ExtResource("2_crphu")]
+layout_mode = 2
+tooltip_text = "The stat that improves accuracy for this weapon."
+myplaceholdertext = "Drop a stat from the list to the left"

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -174,6 +174,7 @@ class Ranged:
 	var used_ammo: String
 	var used_magazine: String
 	var used_skill: Dictionary # example: {"skill_id": "handguns", "xp": 1}
+	var accuracy_stat: String
 
 	# Constructor to initialize ranged properties from a dictionary
 	func _init(data: Dictionary):
@@ -186,6 +187,7 @@ class Ranged:
 		used_ammo = data.get("used_ammo", "")
 		used_magazine = data.get("used_magazine", "")
 		used_skill = data.get("used_skill", {})
+		accuracy_stat = data.get("accuracy_stat", "")
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
@@ -198,7 +200,8 @@ class Ranged:
 			"sway": sway,
 			"used_ammo": used_ammo,
 			"used_magazine": used_magazine,
-			"used_skill": used_skill
+			"used_skill": used_skill,
+			"accuracy_stat": accuracy_stat
 		}
 		
 	# Function to get used skill ID

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -125,15 +125,15 @@ func stat_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void
 	if dropped_data and dropped_data.has("id"):
 		var stat_id = dropped_data["id"]
 		if not Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(stat_id):
-		print_debug("No stat data found for ID: " + stat_id)
-		return
+			print_debug("No stat data found for ID: " + stat_id)
+			return
 		texteditcontrol.set_text(stat_id)
 	else:
 		print_debug("Dropped data does not contain an 'id' key.")
 
 func can_stat_drop(dropped_data: Dictionary):
 	if not dropped_data or not dropped_data.has("id"):
-	        return false
+		return false
 	return Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(dropped_data["id"])
 
 

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -14,6 +14,7 @@ extends Control
 @export var skill_xp_spin_box: SpinBox = null
 @export var ReloadSpeedNumberBox: SpinBox = null
 @export var FiringSpeedNumberBox: SpinBox = null
+@export var accuracy_stat_text_edit: HBoxContainer = null
 
 var ditem: DItem = null:
 	set(value):
@@ -57,6 +58,7 @@ func save_properties() -> void:
 	ditem.ranged.recoil = int(RecoilNumberBox.value)
 	ditem.ranged.reload_speed = ReloadSpeedNumberBox.value
 	ditem.ranged.firing_speed = FiringSpeedNumberBox.value
+	ditem.ranged.accuracy_stat = accuracy_stat_text_edit.get_text()
 	
 	# Only include used_skill if UsedSkillTextEdit has a value
 	if UsedSkillTextEdit.get_text() != "":
@@ -85,6 +87,7 @@ func load_properties() -> void:
 	RecoilNumberBox.value = ditem.ranged.recoil
 	ReloadSpeedNumberBox.value = ditem.ranged.reload_speed
 	FiringSpeedNumberBox.value = ditem.ranged.firing_speed
+	accuracy_stat_text_edit.set_text(ditem.ranged.accuracy_stat)
 	
 	if ditem.ranged.used_skill.has("skill_id"):
 		UsedSkillTextEdit.set_text(ditem.ranged.used_skill["skill_id"])
@@ -118,9 +121,26 @@ func can_skill_drop(dropped_data: Dictionary):
 	# If all checks pass, return true
 	return true
 
+func stat_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
+	if dropped_data and dropped_data.has("id"):
+		var stat_id = dropped_data["id"]
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(stat_id):
+		print_debug("No stat data found for ID: " + stat_id)
+		return
+		texteditcontrol.set_text(stat_id)
+	else:
+		print_debug("Dropped data does not contain an 'id' key.")
+
+func can_stat_drop(dropped_data: Dictionary):
+	if not dropped_data or not dropped_data.has("id"):
+	        return false
+	return Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(dropped_data["id"])
+
 
 # Set the drop functions on the required skill and skill progression controls
 # This enables them to receive drop data
 func set_drop_functions():
 	UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)
 	UsedSkillTextEdit.can_drop_function = can_skill_drop
+	accuracy_stat_text_edit.drop_function = stat_drop.bind(accuracy_stat_text_edit)
+	accuracy_stat_text_edit.can_drop_function = can_stat_drop

--- a/Scripts/Runtimedata/RItem.gd
+++ b/Scripts/Runtimedata/RItem.gd
@@ -104,6 +104,7 @@ class Ranged:
 	var used_ammo: String
 	var used_magazine: String
 	var used_skill: Dictionary
+	var accuracy_stat: String
 
 	func _init(data: Dictionary):
 		firing_speed = data.get("firing_speed", 0.0)
@@ -115,6 +116,7 @@ class Ranged:
 		used_ammo = data.get("used_ammo", "")
 		used_magazine = data.get("used_magazine", "")
 		used_skill = data.get("used_skill", {})
+		accuracy_stat = data.get("accuracy_stat", "")
 
 	func get_data() -> Dictionary:
 		return {
@@ -126,7 +128,8 @@ class Ranged:
 			"sway": sway,
 			"used_ammo": used_ammo,
 			"used_magazine": used_magazine,
-			"used_skill": used_skill
+			"used_skill": used_skill,
+			"accuracy_stat": accuracy_stat
 		}
 
 class Melee:


### PR DESCRIPTION
## Summary
- allow dropping a stat for ranged weapon accuracy
- expose the accuracy stat field in `ItemRangedEditor` UI and script
- store `accuracy_stat` in item data classes
- fix indentation to use tabs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68682b1f2eec83259587c6de2bb78be2