### PR TITLE
Fix saving of Ranged accuracy_stat

### DIFF
--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -191,7 +191,7 @@ class Ranged:
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
-		return {
+		var data: Dictionary = {
 			"firing_speed": firing_speed,
 			"range": firing_range,
 			"recoil": recoil,
@@ -200,9 +200,11 @@ class Ranged:
 			"sway": sway,
 			"used_ammo": used_ammo,
 			"used_magazine": used_magazine,
-			"used_skill": used_skill,
-			"accuracy_stat": accuracy_stat
+			"used_skill": used_skill
 		}
+		if accuracy_stat != "":
+			data["accuracy_stat"] = accuracy_stat
+		return data
 		
 	# Function to get used skill ID
 	func get_used_skill_ids() -> Array:

--- a/Scripts/Runtimedata/RItem.gd
+++ b/Scripts/Runtimedata/RItem.gd
@@ -119,7 +119,7 @@ class Ranged:
 		accuracy_stat = data.get("accuracy_stat", "")
 
 	func get_data() -> Dictionary:
-		return {
+		var data: Dictionary = {
 			"firing_speed": firing_speed,
 			"range": firing_range,
 			"recoil": recoil,
@@ -128,9 +128,11 @@ class Ranged:
 			"sway": sway,
 			"used_ammo": used_ammo,
 			"used_magazine": used_magazine,
-			"used_skill": used_skill,
-			"accuracy_stat": accuracy_stat
+			"used_skill": used_skill
 		}
+		if accuracy_stat != "":
+			data["accuracy_stat"] = accuracy_stat
+		return data
 
 class Melee:
 	var damage: int


### PR DESCRIPTION
## Summary
- include `accuracy_stat` only when non-empty in `DItem.Ranged.get_data`
- include `accuracy_stat` only when non-empty in `RItem.Ranged.get_data`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695d9fee0483259369b6aa76f9cf21