### PR TITLE
Fix DropEntityTextEdit clear behavior

### DIFF
--- a/Scenes/ContentManager/Custom_Widgets/Scripts/DropEntityTextEdit.gd
+++ b/Scenes/ContentManager/Custom_Widgets/Scripts/DropEntityTextEdit.gd
@@ -70,6 +70,7 @@ func _drop_data(newpos, data) -> void:
 
 func _on_button_button_up():
 	mytextedit.clear()
+	dropped_data = {}
 	text_changed.emit("")
 
 


### PR DESCRIPTION
## Summary
- reset `dropped_data` when clearing the text edit

## Testing
- `apt-get update`
- `apt-get install -y godot4` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68695f20297483259a4860b4e36eb77e