### PR TITLE
Fix small grammar issues in documentation

### DIFF
--- a/Documentation/Modding/Documentation/Creating_documentation.md
+++ b/Documentation/Modding/Documentation/Creating_documentation.md
@@ -1,9 +1,9 @@
 ### Help creation
 This page includes information about creating documentation files
 
-The format of documentation files should be .md. The contents of the file should contain **Github Flavored Markdown** formatted text. Since the documentation will also be viewable in-game, only the formatting supported by [this addon](https://github.com/daenvil/MarkdownLabel) will work.
+Documentation files should use the `.md` format. The contents of the file should contain **GitHub Flavored Markdown** formatted text. Since the documentation will also be viewable in-game, only the formatting supported by [this addon](https://github.com/daenvil/MarkdownLabel) will work.
 
-Put new documentation files inside one of the folders in the `Documentation` folder. If needed, create a new subfolder. The documentation files either be edited locally, or in your browser using the editor on Github. When editing in Github, keep the formatting limitations described above in mind.
+Put new documentation files inside one of the folders in the `Documentation` folder. If needed, create a new subfolder. The documentation files can be edited locally or in your browser using the editor on GitHub. When editing in GitHub, keep the formatting limitations described above in mind.
 
 ### File names
-File names should start with a capital letter. Instead of a space " ", use an unders core _. Keep in mind that in the in-game menu, the file name will be the display name in the documentation list and underscores will be replaced with a space.
+File names should start with a capital letter. Instead of a space " ", use an underscore _. Keep in mind that in the in-game menu, the file name will be the display name in the documentation list, and underscores will be replaced with spaces.


### PR DESCRIPTION
## Summary
- fix instructions about documentation filenames and GitHub references

## Testing
- `apt-get update`
- `apt-get install godot4` *(fails: Unable to locate package)*
- `curl -L -o godot.zip https://downloads.tuxfamily.org/godotengine/4.2.1/Godot_v4.2.1-stable_linux.x86_64.zip` *(fails: connection timeout)*

------
https://chatgpt.com/codex/tasks/task_e_686960656c6883258b2c5fa8e02156b4