### PR TITLE
docs: update Running tests section

### DIFF
--- a/Documentation/Game_development/Getting_started.md
+++ b/Documentation/Game_development/Getting_started.md
@@ -93,3 +93,7 @@ UI is another area that is somewhat accessible to contributors starting out. Thi
 Keep in mind that the UI communicates with the game world through autoloads. For example, the Inventory menu works together with the `ItemManager` (`/Scripts/item_manager.gd`). Some game elements like the player and some windows communicate through `Helper.signal_broker`. To find out what connects to what, press `ctrl+shift+f` in Godot and search for `Helper.signal_broker` and a list will come up.
 
 Icons used in the UI can be found in `/Textures` and `/Images/Icons`. Sometimes you don't need to use an icon and a button with an `x` or arrow `->` will suffice. In the case of the character menu, the icons are loaded from the mod data in `/Mods/Core/Stats` and `/Mods/Core/Stats`
+## Running tests
+The project uses the [GUT](https://github.com/bitwes/Gut) addon for unit testing. Tests are managed inside the Godot editor.
+
+Open the project in Godot and look at the bottom panel of the window. Next to `Output` and `Debugger` you will find the `GUT` tab. Click it to open the control panel where you can run all tests or filter them by directory or file.


### PR DESCRIPTION
## Summary
- clarify testing instructions for Godot's GUT addon

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869608a35548325a882638846a18563