### PR TITLE
Update stat references for ranged items

### DIFF
--- a/Mods/Core/Stats/references.json
+++ b/Mods/Core/Stats/references.json
@@ -1,0 +1,7 @@
+{
+	"dexterity": {
+		"items": [
+			"pistol_9mm"
+		]
+	}
+}

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -84,6 +84,7 @@
 	},
 	{
 		"Ranged": {
+			"accuracy_stat": "dexterity",
 			"firing_speed": 0.4,
 			"range": 1000,
 			"recoil": 10,

--- a/Mods/Test/Stats/references.json
+++ b/Mods/Test/Stats/references.json
@@ -1,0 +1,7 @@
+{
+	"dexterity": {
+		"items": [
+			"pistol_9mm"
+		]
+	}
+}

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -540,10 +540,11 @@ func changed(olddata: DItem):
 			Gamedata.mods.remove_reference(DMod.ContentType.ITEMS, res_id, DMod.ContentType.ITEMS, id)
 	
 	# Add references for new resources, nothing happens if they are already present
-	for res_id in new_resource_ids:
-		Gamedata.mods.add_reference(DMod.ContentType.ITEMS, res_id, DMod.ContentType.ITEMS, id)
-	update_item_skill_references(olddata)
-	update_item_attribute_references(olddata)
+		for res_id in new_resource_ids:
+				Gamedata.mods.add_reference(DMod.ContentType.ITEMS, res_id, DMod.ContentType.ITEMS, id)
+		update_item_skill_references(olddata)
+		update_item_stat_references(olddata)
+		update_item_attribute_references(olddata)
 	
 	parent.save_items_to_disk()
 
@@ -612,7 +613,22 @@ func update_item_skill_references(olddata: DItem):
 	
 	# Add new skill references
 	for new_skill_id in new_skill_ids:
-		Gamedata.mods.add_reference(DMod.ContentType.SKILLS, new_skill_id, DMod.ContentType.ITEMS, id)
+				Gamedata.mods.add_reference(DMod.ContentType.SKILLS, new_skill_id, DMod.ContentType.ITEMS, id)
+
+# Updates references between the ranged item's accuracy stat and the stat entity
+func update_item_stat_references(olddata: DItem):
+		var old_stat_id := ""
+		if olddata.ranged and olddata.ranged.accuracy_stat != "":
+				old_stat_id = olddata.ranged.accuracy_stat
+		var new_stat_id := ""
+		if ranged and ranged.accuracy_stat != "":
+				new_stat_id = ranged.accuracy_stat
+
+		if old_stat_id != new_stat_id:
+				if old_stat_id != "":
+						Gamedata.mods.remove_reference(DMod.ContentType.STATS, old_stat_id, DMod.ContentType.ITEMS, id)
+				if new_stat_id != "":
+						Gamedata.mods.add_reference(DMod.ContentType.STATS, new_stat_id, DMod.ContentType.ITEMS, id)
 
 
 # Collects all attributes defined in an item and updates the references to that attribute
@@ -690,9 +706,12 @@ func delete():
 	if melee and melee.used_skill:
 		skill_ids[melee.used_skill.skill_id] = true
 
-	# Remove the reference of this item from each skill
+# Remove the reference of this item from each skill
 	for skill_id in skill_ids.keys():
 		Gamedata.mods.remove_reference(DMod.ContentType.SKILLS, skill_id, DMod.ContentType.ITEMS, id)
+
+	if ranged and ranged.accuracy_stat != "":
+		Gamedata.mods.remove_reference(DMod.ContentType.STATS, ranged.accuracy_stat, DMod.ContentType.ITEMS, id)
 
 
 # Function to remove all instances of a skill from the item

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -540,11 +540,11 @@ func changed(olddata: DItem):
 			Gamedata.mods.remove_reference(DMod.ContentType.ITEMS, res_id, DMod.ContentType.ITEMS, id)
 	
 	# Add references for new resources, nothing happens if they are already present
-		for res_id in new_resource_ids:
-				Gamedata.mods.add_reference(DMod.ContentType.ITEMS, res_id, DMod.ContentType.ITEMS, id)
-		update_item_skill_references(olddata)
-		update_item_stat_references(olddata)
-		update_item_attribute_references(olddata)
+	for res_id in new_resource_ids:
+		Gamedata.mods.add_reference(DMod.ContentType.ITEMS, res_id, DMod.ContentType.ITEMS, id)
+	update_item_skill_references(olddata)
+	update_item_stat_references(olddata)
+	update_item_attribute_references(olddata)
 	
 	parent.save_items_to_disk()
 

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -613,22 +613,22 @@ func update_item_skill_references(olddata: DItem):
 	
 	# Add new skill references
 	for new_skill_id in new_skill_ids:
-				Gamedata.mods.add_reference(DMod.ContentType.SKILLS, new_skill_id, DMod.ContentType.ITEMS, id)
+		Gamedata.mods.add_reference(DMod.ContentType.SKILLS, new_skill_id, DMod.ContentType.ITEMS, id)
 
 # Updates references between the ranged item's accuracy stat and the stat entity
 func update_item_stat_references(olddata: DItem):
-		var old_stat_id := ""
-		if olddata.ranged and olddata.ranged.accuracy_stat != "":
-				old_stat_id = olddata.ranged.accuracy_stat
-		var new_stat_id := ""
-		if ranged and ranged.accuracy_stat != "":
-				new_stat_id = ranged.accuracy_stat
+	var old_stat_id := ""
+	if olddata.ranged and olddata.ranged.accuracy_stat != "":
+		old_stat_id = olddata.ranged.accuracy_stat
+	var new_stat_id := ""
+	if ranged and ranged.accuracy_stat != "":
+		new_stat_id = ranged.accuracy_stat
 
-		if old_stat_id != new_stat_id:
-				if old_stat_id != "":
-						Gamedata.mods.remove_reference(DMod.ContentType.STATS, old_stat_id, DMod.ContentType.ITEMS, id)
-				if new_stat_id != "":
-						Gamedata.mods.add_reference(DMod.ContentType.STATS, new_stat_id, DMod.ContentType.ITEMS, id)
+	if old_stat_id != new_stat_id:
+		if old_stat_id != "":
+			Gamedata.mods.remove_reference(DMod.ContentType.STATS, old_stat_id, DMod.ContentType.ITEMS, id)
+		if new_stat_id != "":
+			Gamedata.mods.add_reference(DMod.ContentType.STATS, new_stat_id, DMod.ContentType.ITEMS, id)
 
 
 # Collects all attributes defined in an item and updates the references to that attribute

--- a/Scripts/Gamedata/DStats.gd
+++ b/Scripts/Gamedata/DStats.gd
@@ -18,7 +18,7 @@ var mod_id: String = "Core"
 func _init(new_mod_id: String) -> void:
 	mod_id = new_mod_id
 	# Update dataPath and spritePath using the provided mod_id
-	dataPath = "./Mods/" + mod_id + "/Stats/Stats.json"
+	dataPath = "./Mods/" + mod_id + "/Stats/"
 	file_path = "./Mods/" + mod_id + "/Stats/Stats.json"
 	spritePath = "./Mods/" + mod_id + "/Stats/"
 	

--- a/Scripts/Gamedata/DStats.gd
+++ b/Scripts/Gamedata/DStats.gd
@@ -10,6 +10,7 @@ var dataPath: String = "./Mods/Core/Stats/Stats.json"
 var spritePath: String = "./Mods/Core/Stats/"
 var statdict: Dictionary = {}
 var sprites: Dictionary = {}
+var references: Dictionary = {}
 var mod_id: String = "Core"
 
 # Add a mod_id parameter to dynamically initialize paths
@@ -20,18 +21,27 @@ func _init(new_mod_id: String) -> void:
 	spritePath = "./Mods/" + mod_id + "/Stats/"
 	
 	# Load stats and sprites
-	load_sprites()
-	load_stats_from_disk()
+		load_sprites()
+		load_stats_from_disk()
+		load_references()
 
 
 # Load all stats data from disk into memory
 func load_stats_from_disk() -> void:
-	var statslist: Array = Helper.json_helper.load_json_array_file(dataPath)
-	for mystat in statslist:
-		var stat: DStat = DStat.new(mystat, self)
-		if stat.spriteid:
-			stat.sprite = sprites[stat.spriteid]
-		statdict[stat.id] = stat
+		var statslist: Array = Helper.json_helper.load_json_array_file(dataPath)
+		for mystat in statslist:
+				var stat: DStat = DStat.new(mystat, self)
+				if stat.spriteid:
+						stat.sprite = sprites[stat.spriteid]
+				statdict[stat.id] = stat
+
+# Load references from references.json
+func load_references() -> void:
+		var path = dataPath.get_base_dir() + "/references.json"
+		if FileAccess.file_exists(path):
+				references = Helper.json_helper.load_json_dictionary_file(path)
+		else:
+				references = {}
 
 # Loads sprites and assigns them to the proper dictionary
 func load_sprites() -> void:

--- a/Scripts/Gamedata/DStats.gd
+++ b/Scripts/Gamedata/DStats.gd
@@ -6,7 +6,8 @@ extends RefCounted
 # This script handles the list of stats. You can access it through Gamedata.mods.by_id("Core").stats
 
 # Paths for stats data and sprites
-var dataPath: String = "./Mods/Core/Stats/Stats.json"
+var dataPath: String = "./Mods/Core/Stats/"
+var file_path: String = "./Mods/Core/Stats/Stats.json"
 var spritePath: String = "./Mods/Core/Stats/"
 var statdict: Dictionary = {}
 var sprites: Dictionary = {}
@@ -18,22 +19,23 @@ func _init(new_mod_id: String) -> void:
 	mod_id = new_mod_id
 	# Update dataPath and spritePath using the provided mod_id
 	dataPath = "./Mods/" + mod_id + "/Stats/Stats.json"
+	file_path = "./Mods/" + mod_id + "/Stats/Stats.json"
 	spritePath = "./Mods/" + mod_id + "/Stats/"
 	
 	# Load stats and sprites
-		load_sprites()
-		load_stats_from_disk()
-		load_references()
+	load_sprites()
+	load_stats_from_disk()
+	load_references()
 
 
 # Load all stats data from disk into memory
 func load_stats_from_disk() -> void:
-		var statslist: Array = Helper.json_helper.load_json_array_file(dataPath)
+		var statslist: Array = Helper.json_helper.load_json_array_file(file_path)
 		for mystat in statslist:
-				var stat: DStat = DStat.new(mystat, self)
-				if stat.spriteid:
-						stat.sprite = sprites[stat.spriteid]
-				statdict[stat.id] = stat
+			var stat: DStat = DStat.new(mystat, self)
+			if stat.spriteid:
+					stat.sprite = sprites[stat.spriteid]
+			statdict[stat.id] = stat
 
 # Load references from references.json
 func load_references() -> void:
@@ -61,7 +63,7 @@ func save_stats_to_disk() -> void:
 	var save_data: Array = []
 	for stat in statdict.values():
 		save_data.append(stat.get_data())
-	Helper.json_helper.write_json_file(dataPath, JSON.stringify(save_data, "\t"))
+	Helper.json_helper.write_json_file(file_path, JSON.stringify(save_data, "\t"))
 
 # Returns the dictionary containing all stats
 func get_all() -> Dictionary:


### PR DESCRIPTION
## Summary
- load `references.json` in `DStats`
- track stat references from ranged items in `DItem`
- switch indentation to tabs

## Testing
- `godot4 --headless -s addons/gut/gut_cmdln.gd -gdir=res://Tests/Unit -gexit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686964b2876c83259d6b7ce47f7564a8