### PR TITLE
Fix mob movement test

### DIFF
--- a/Scripts/Mob/MobIdle.gd
+++ b/Scripts/Mob/MobIdle.gd
@@ -53,7 +53,11 @@ func handle_mob_movement():
 		is_looking_to_move = false
 
 func move_mob_to_target():
-	var dir = mob.to_local(nav_agent.get_next_path_position()).normalized()
+	var dir: Vector3
+	if nav_agent.is_navigation_finished():
+		dir = mob.global_position.direction_to(target_location)
+	else:
+		dir = mob.to_local(nav_agent.get_next_path_position()).normalized()
 	mob.velocity = dir * mob.current_idle_move_speed
 	mob.move_and_slide()
 	
@@ -72,7 +76,8 @@ func makepath() -> void:
 
 func _on_moving_cooldown_timeout():
 	var space_state = get_world_3d().direct_space_state
-	var random_dir = Vector3(rng.randf_range(-1,1), mob.global_position.y, rng.randf_range(-1, 1))
+	var random_dir = Vector3(rng.randf_range(-1,1), 0.0, rng.randf_range(-1, 1))
+	# Keep movement on the horizontal plane to ensure the target is on the navigation mesh.
 	var query = PhysicsRayQueryParameters3D.create(mob.global_position, mob.global_position + (random_dir * move_distance), int(pow(2, 1-1) + pow(2, 3-1)),[self])
 
 	var result = space_state.intersect_ray(query)


### PR DESCRIPTION
## Summary
- correct MobIdle movement direction
- ensure mobs move even without a navigation path
- add comment explaining horizontal movement check

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_686e4c0ae4d08325aa115be7662f8051