### PR TITLE
Add tasks for melee weapon stat PRD

### DIFF
--- a/.project-management/current-prd/tasks-feature-melee-stats.md
+++ b/.project-management/current-prd/tasks-feature-melee-stats.md
@@ -1,0 +1,60 @@
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Assets
+├── Defaults
+├── Documentation
+├── FeatureList.md
+├── Images
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── Media
+├── Mods
+├── README.md
+├── Scenes
+├── Scripts
+├── Shaders
+├── Sounds
+├── Tests
+├── Textures
+├── day_night.gd
+├── day_night.gd.uid
+├── day_night.tscn
+├── documentation.tscn
+├── entity_manager.gd
+├── entity_manager.gd.uid
+├── export_presets.cfg
+├── front_light.gd
+├── front_light.gd.uid
+├── front_light.tscn
+├── hud.tscn
+├── icon.svg
+├── icon.svg.import
+├── level_generation.tscn
+├── override.cfg
+├── project.godot
+├── scene_selector.tscn
+├── spot_light_3d.tscn
+├── spot_light_3d_2.tscn
+├── test_environment.gd
+├── test_environment.gd.uid
+├── test_environment.tscn
+└── torso.aseprite
+
+13 directories, 33 files
+```
+
+## Tasks
+- [ ] 1.0 Add stat entry field to `Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn` using `DropEntityTextEdit.tscn`.
+- [ ] 2.0 Update `Scripts/ItemMeleeEditor.gd` to load, save, and validate the melee bonus stat using drop logic.
+- [ ] 3.0 Extend `Scripts/Gamedata/DItem.gd` Melee class to store the selected stat and maintain references.
+- [ ] 4.0 Apply the stat-based bonus during melee combat calculations.
+- [ ] 5.0 Write unit tests validating the new field and bonus logic.
+
+*End of document*


### PR DESCRIPTION
## Summary
- generate initial task list for the melee stat feature PRD

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_686f74aa89c08325b33aaabefc8db1c7