### PR TITLE
Add PRD for placeholder cleanup

### DIFF
--- a/.project-management/current-prd/prd-placeholder-cleanup.md
+++ b/.project-management/current-prd/prd-placeholder-cleanup.md
@@ -1,0 +1,46 @@
+## 1. Introduction/Overview
+This feature focuses on cleaning the codebase by removing placeholder comments and stub functions. It targets scripts under `Scenes/ContentManager/Mapeditor/Scripts` and `Scripts`. These placeholders confuse developers and add noise to the repository. The goal is to eliminate them so that the codebase reflects only meaningful logic.
+
+## 2. Goals
+- Remove all comments referencing "Replace with function body".
+- Delete or clean stub methods that contain only placeholder logic.
+- Ensure the project builds and existing unit tests pass after cleanup.
+
+## 3. User Stories
+- **As a developer**, I want to read scripts without placeholder comments so that the intent of each function is clear.
+- **As a developer**, I want unused stub methods removed to reduce clutter when navigating the code.
+
+## 4. Functional Requirements
+1. Identify all occurrences of the text "Replace with function body" in `Scenes/ContentManager/Mapeditor/Scripts` and `Scripts`.
+2. For each occurrence:
+   - If the method body only contains a `pass` statement, delete the entire function.
+   - If the method contains other logic, remove only the placeholder comment.
+3. Confirm the cleanup for at least:
+   - `Map_Editor_Areas_Popup.gd`
+   - `weapon.gd`
+   - `test_environment.gd`
+   - Any additional scripts containing the placeholder text.
+4. Run the default GUT tests to validate the project after modifications.
+
+## 5. Non-Goals (Out of Scope)
+- Implementing new functionality or gameplay changes.
+- Modifying the map editor interface or its scene files.
+- Changing behavior beyond removing placeholder code.
+
+## 6. Design Considerations
+- None. No UI updates are planned.
+
+## 7. Technical Considerations
+- Follow Godot 4.4 and GDScript 4 style conventions (tabs for indentation, `class_name` usage where needed).
+- Ensure no broken signal connections or references remain after removing functions.
+
+## 8. Success Metrics
+- All placeholder comments are gone from the specified directories.
+- Stub methods containing only placeholders are removed without introducing runtime errors.
+- `godot --headless` unit tests pass.
+
+## 9. Open Questions
+- Are there additional scripts outside the specified folders that contain similar placeholders?
+
+## 10. Referenced PRD-background files
+- `.project-management/current-prd/prd-background/feature-specification.md` – describes the search for "Replace with function body" comments and enumerates targeted scripts.


### PR DESCRIPTION
## Summary
- create `prd-placeholder-cleanup.md` describing removal of placeholder comments and functions

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_686fffb63eac8325bd88a1feb6508d80