### PR TITLE
Add PRD for pointer3 import issue

### DIFF
--- a/.project-management/current-prd/prd-remove-pointer3.md
+++ b/.project-management/current-prd/prd-remove-pointer3.md
@@ -1,0 +1,36 @@
+## 1. Introduction/Overview
+Pointer3.png is referenced as the custom mouse cursor image in `project.godot`. During headless import, Godot cannot find the imported texture `.godot/imported/pointer3.png-daf3916ed3afea06b8c4267b5a72e06f.ctex`, leading to errors. The goal of this feature is to analyze the usage of `pointer3.png` and decide whether to remove it or restore the missing asset so that import completes without errors.
+
+## 2. Goals
+- Determine the role and necessity of `pointer3.png` in the game.
+- Ensure `godot --headless --import` runs with no missing file errors.
+- If `pointer3.png` is unnecessary, remove references and delete the file.
+
+## 3. User Stories
+- *As a developer*, I want to know where `pointer3.png` is referenced so I can assess its importance.
+- *As a developer*, I want the import process to run cleanly without missing resource errors.
+
+## 4. Functional Requirements
+1. The system must identify every reference to `pointer3.png` (currently found in `project.godot`).
+2. The project must either include a valid imported asset for `pointer3.png` or remove all references to it.
+3. Running `godot --headless --import` must complete without failing to load `pointer3.png`.
+
+## 5. Non-Goals (Out of Scope)
+- Implementing fallback pointer logic is not required.
+- No other asset issues will be addressed in this feature.
+
+## 6. Design Considerations (Optional)
+- If removing the pointer, update `project.godot` to use `pointer2.png` or the default cursor so that gameplay remains unaffected.
+
+## 7. Technical Considerations (Optional)
+- Deleting `pointer3.png` requires also deleting `Textures/pointer3.png.import` and removing the line in `project.godot` referencing it.
+- The missing `.godot/imported` texture may be recreated by opening the project in Godot and reimporting assets.
+
+## 8. Success Metrics
+- `godot --headless --import` runs with zero missing resource errors.
+
+## 9. Open Questions
+- Should the project maintain a custom cursor image, or is reverting to the default acceptable?
+
+## 10. Referenced PRD-background files
+- `.project-management/current-prd/prd-background/feature-specification.md` – details the error messages and tasks related to `pointer3.png`.


### PR DESCRIPTION
## Summary
- add product requirements for analyzing/removing `pointer3.png` import error

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_687144e9b62c8325af5db05b0412de33