### PR TITLE
Close PRD - finalize melee stat feature

### DIFF
--- a/.project-management/current-prd/tasks-feature-melee-stats.md
+++ b/.project-management/current-prd/tasks-feature-melee-stats.md
@@ -56,5 +56,6 @@
 - [x] 3.0 Extend `Scripts/Gamedata/DItem.gd` Melee class to store the selected stat and maintain references.
 - [x] 4.0 Apply the stat-based bonus during melee combat calculations.
 - [x] 5.0 Write unit tests validating the new field and bonus logic.
+- [ ] 6.0 Review newly added accuracy stat support for melee weapons.
 
 *End of document*

--- a/Mods/Core/Stats/references.json
+++ b/Mods/Core/Stats/references.json
@@ -1,7 +1,8 @@
 {
 	"dexterity": {
 		"items": [
-			"pistol_9mm"
+			"pistol_9mm",
+			"stone_spear"
 		]
 	},
 	"strength": {

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -2457,6 +2457,7 @@
 			}
 		],
 		"Melee": {
+			"accuracy_stat": "dexterity",
 			"damage": 17,
 			"damage_stat": "strength",
 			"reach": 2,

--- a/Mods/Test/Stats/references.json
+++ b/Mods/Test/Stats/references.json
@@ -1,7 +1,8 @@
 {
 	"dexterity": {
 		"items": [
-			"pistol_9mm"
+			"pistol_9mm",
+			"stone_spear"
 		]
 	},
 	"strength": {

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_etmci"]
 [ext_resource type="PackedScene" uid="uid://dmlbg7nolncnh" path="res://Scenes/ContentManager/Custom_Widgets/DropEntityTextEdit.tscn" id="3_kgnfh"]
 
-[node name="ItemMeleeEditor" type="Control" node_paths=PackedStringArray("DamageSpinBox", "ReachSpinBox", "UsedSkillTextEdit", "skill_xp_spin_box", "damage_stat_text_edit")]
+[node name="ItemMeleeEditor" type="Control" node_paths=PackedStringArray("DamageSpinBox", "ReachSpinBox", "UsedSkillTextEdit", "skill_xp_spin_box", "damage_stat_text_edit", "accuracy_stat_text_edit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -17,6 +17,7 @@ ReachSpinBox = NodePath("Melee/ReachSpinbox")
 UsedSkillTextEdit = NodePath("Melee/UsedSkillHBoxContainer/UsedSkillTextEdit")
 skill_xp_spin_box = NodePath("Melee/UsedSkillHBoxContainer/SkillXPSpinBox")
 damage_stat_text_edit = NodePath("Melee/DamageStatTextEdit")
+accuracy_stat_text_edit = NodePath("Melee/AccuracyStatTextEdit")
 
 [node name="Melee" type="GridContainer" parent="."]
 layout_mode = 0
@@ -71,4 +72,12 @@ text = "Damage Stat"
 [node name="DamageStatTextEdit" parent="Melee" instance=ExtResource("3_kgnfh")]
 layout_mode = 2
 tooltip_text = "The stat that increases melee damage for this weapon."
+myplaceholdertext = "Drop a stat from the list"
+[node name="AccuracyStatLabel" type="Label" parent="Melee"]
+layout_mode = 2
+text = "Accuracy Stat"
+
+[node name="AccuracyStatTextEdit" parent="Melee" instance=ExtResource("3_kgnfh")]
+layout_mode = 2
+tooltip_text = "The stat that improves accuracy for this weapon."
 myplaceholdertext = "Drop a stat from the list"

--- a/Scripts/EquippedItem.gd
+++ b/Scripts/EquippedItem.gd
@@ -393,15 +393,19 @@ func _calculate_melee_attack_data() -> Dictionary:
 	var damage = melee_properties.get("damage", 0)
 	var skill_id = melee_properties.get("used_skill", {}).get("skill_id", "")
 	var skill_level = player.get_skill_level(skill_id)
-	var stat_bonus = 0
-	var dex = 0
-if player.has_method("get_stat"):
-var damage_stat_id = melee_properties.get("damage_stat", "strength")
-stat_bonus = player.get_stat(damage_stat_id)
-var accuracy_stat_id = melee_properties.get("accuracy_stat", "dexterity")
-dex = player.get_stat(accuracy_stat_id)
-	damage += stat_bonus
-	var hit_chance = 0.65 + ((skill_level + dex) / 100.0) * (1.0 - 0.65)
+	
+	# Add bonuses based on stats
+	var damage_stat_bonus = 0
+	var accuracy_stat_bonus = 0
+	if player.has_method("get_stat"):
+		# Add damage bonus based on selected stat OR strength if nothing is configured for the item
+		var damage_stat_id = melee_properties.get("damage_stat", "strength")
+		damage_stat_bonus = player.get_stat(damage_stat_id)
+		damage += damage_stat_bonus
+		# Add accuracy bonus based on selected stat OR dexterity if nothing is configured for the item
+		var accuracy_stat_id = melee_properties.get("accuracy_stat", "dexterity")
+		accuracy_stat_bonus = player.get_stat(accuracy_stat_id)
+	var hit_chance = 0.65 + ((skill_level + accuracy_stat_bonus) / 100.0) * (1.0 - 0.65)
 
 	return {"damage": damage, "hit_chance": hit_chance}
 

--- a/Scripts/EquippedItem.gd
+++ b/Scripts/EquippedItem.gd
@@ -395,10 +395,11 @@ func _calculate_melee_attack_data() -> Dictionary:
 	var skill_level = player.get_skill_level(skill_id)
 	var stat_bonus = 0
 	var dex = 0
-	if player.has_method("get_stat"):
-		var stat_id = melee_properties.get("damage_stat", "strength")
-		stat_bonus = player.get_stat(stat_id)
-		dex = player.get_stat("dexterity")
+if player.has_method("get_stat"):
+var damage_stat_id = melee_properties.get("damage_stat", "strength")
+stat_bonus = player.get_stat(damage_stat_id)
+var accuracy_stat_id = melee_properties.get("accuracy_stat", "dexterity")
+dex = player.get_stat(accuracy_stat_id)
 	damage += stat_bonus
 	var hit_chance = 0.65 + ((skill_level + dex) / 100.0) * (1.0 - 0.65)
 

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -204,7 +204,7 @@ class Ranged:
 		}
 		if accuracy_stat != "":
 			data["accuracy_stat"] = accuracy_stat
-		return data
+				return data
 		
 	# Function to get used skill ID
 	func get_used_skill_ids() -> Array:
@@ -226,6 +226,7 @@ class Melee:
 	var reach: int
 	var used_skill: Dictionary # example: {"skill_id": "bashing", "xp": 1}
 	var damage_stat: String
+	var accuracy_stat: String
 
 	# Constructor to initialize melee properties from a dictionary
 	func _init(data: Dictionary):
@@ -233,6 +234,7 @@ class Melee:
 		reach = data.get("reach", 0)
 		used_skill = data.get("used_skill", {})
 		damage_stat = data.get("damage_stat", "")
+		accuracy_stat = data.get("accuracy_stat", "")
 
 	# Get data function to return a dictionary with all properties
 	func get_data() -> Dictionary:
@@ -243,7 +245,9 @@ class Melee:
 		}
 		if damage_stat != "":
 			data["damage_stat"] = damage_stat
-		return data
+		if accuracy_stat != "":
+			data["accuracy_stat"] = accuracy_stat
+				return data
 
 	# Function to get used skill ID
 	func get_used_skill_ids() -> Array:
@@ -492,7 +496,7 @@ func get_data() -> Dictionary:
 		if not wearabledata.is_empty():
 			data["Wearable"] = wearabledata
 
-	return data
+				return data
 
 
 # Returns the path of the sprite

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -624,24 +624,56 @@ func update_item_skill_references(olddata: DItem):
 	for new_skill_id in new_skill_ids:
 		Gamedata.mods.add_reference(DMod.ContentType.SKILLS, new_skill_id, DMod.ContentType.ITEMS, id)
 
-# Updates references between the ranged item's accuracy stat and the stat entity
-func update_item_stat_references(olddata: DItem):
-	var old_stat_id := ""
+# Updates references between this item’s accuracy & damage stats and the stat entities
+func update_item_stat_references(olddata: DItem) -> void:
+	# 1) Collect old stats
+	var old_stats: Array[String] = []
 	if olddata.ranged and olddata.ranged.accuracy_stat != "":
-		old_stat_id = olddata.ranged.accuracy_stat
-	elif olddata.melee and olddata.melee.damage_stat != "":
-		old_stat_id = olddata.melee.damage_stat
-	var new_stat_id := ""
-	if ranged and ranged.accuracy_stat != "":
-		new_stat_id = ranged.accuracy_stat
-	elif melee and melee.damage_stat != "":
-		new_stat_id = melee.damage_stat
+		old_stats.append(olddata.ranged.accuracy_stat)
+	if olddata.melee:
+		old_stats.append(olddata.melee.damage_stat)
+		old_stats.append(olddata.melee.accuracy_stat)
 
-	if old_stat_id != new_stat_id:
-		if old_stat_id != "":
-			Gamedata.mods.remove_reference(DMod.ContentType.STATS, old_stat_id, DMod.ContentType.ITEMS, id)
-		if new_stat_id != "":
-			Gamedata.mods.add_reference(DMod.ContentType.STATS, new_stat_id, DMod.ContentType.ITEMS, id)
+	# 2) Clean out empty and dedupe
+	old_stats = old_stats.filter(func(id): return id != "")
+	old_stats = _dedupe_array(old_stats)
+
+	# 3) Collect new stats (from this item's current data)
+	var new_stats: Array[String] = []
+	if ranged and ranged.accuracy_stat != "":
+		new_stats.append(ranged.accuracy_stat)
+	if melee:
+		new_stats.append(melee.damage_stat)
+		new_stats.append(melee.accuracy_stat)
+
+	# 4) Clean out empty and dedupe
+	new_stats = new_stats.filter(func(id): return id != "")
+	new_stats = _dedupe_array(new_stats)
+
+	# 5) Remove references for stats we no longer use
+	for stat_id in old_stats:
+		if not new_stats.has(stat_id):
+			Gamedata.mods.remove_reference(
+				DMod.ContentType.STATS, stat_id,
+				DMod.ContentType.ITEMS, id
+			)
+
+	# 6) Add references for newly used stats
+	for stat_id in new_stats:
+		Gamedata.mods.add_reference(
+			DMod.ContentType.STATS, stat_id,
+			DMod.ContentType.ITEMS, id
+		)
+
+# Helper to remove duplicates while preserving order
+func _dedupe_array(arr: Array[String]) -> Array[String]:
+	var seen := {}
+	var result: Array[String] = []
+	for element in arr:
+		if not seen.has(element):
+			seen[element] = true
+			result.append(element)
+	return result
 
 
 # Collects all attributes defined in an item and updates the references to that attribute

--- a/Scripts/Gamedata/DItem.gd
+++ b/Scripts/Gamedata/DItem.gd
@@ -204,7 +204,7 @@ class Ranged:
 		}
 		if accuracy_stat != "":
 			data["accuracy_stat"] = accuracy_stat
-				return data
+		return data
 		
 	# Function to get used skill ID
 	func get_used_skill_ids() -> Array:
@@ -247,7 +247,7 @@ class Melee:
 			data["damage_stat"] = damage_stat
 		if accuracy_stat != "":
 			data["accuracy_stat"] = accuracy_stat
-				return data
+		return data
 
 	# Function to get used skill ID
 	func get_used_skill_ids() -> Array:
@@ -496,7 +496,7 @@ func get_data() -> Dictionary:
 		if not wearabledata.is_empty():
 			data["Wearable"] = wearabledata
 
-				return data
+	return data
 
 
 # Returns the path of the sprite

--- a/Scripts/ItemMeleeEditor.gd
+++ b/Scripts/ItemMeleeEditor.gd
@@ -18,10 +18,10 @@ var ditem: DItem = null:
 		ditem = value
 		load_properties()
 	
-			func _ready():
-			set_drop_functions()
-damage_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
-accuracy_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
+func _ready():
+	set_drop_functions()
+	damage_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
+	accuracy_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
 
 # Load the properties from the ditem.melee and update the UI elements
 func load_properties() -> void:
@@ -37,17 +37,17 @@ func load_properties() -> void:
 				UsedSkillTextEdit.set_text(ditem.melee.used_skill["skill_id"])
 		if ditem.melee.used_skill.has("xp"):
 				skill_xp_spin_box.value = ditem.melee.used_skill["xp"]
-if ditem.melee.damage_stat != "":
-damage_stat_text_edit.set_text(ditem.melee.damage_stat)
-if ditem.melee.accuracy_stat != "":
-accuracy_stat_text_edit.set_text(ditem.melee.accuracy_stat)
+	if ditem.melee.damage_stat != "":
+		damage_stat_text_edit.set_text(ditem.melee.damage_stat)
+	if ditem.melee.accuracy_stat != "":
+		accuracy_stat_text_edit.set_text(ditem.melee.accuracy_stat)
 
 # Save the properties from the UI elements back to ditem.melee
 func save_properties() -> void:
 	ditem.melee.damage = int(DamageSpinBox.value)
 	ditem.melee.reach = int(ReachSpinBox.value)
-ditem.melee.damage_stat = damage_stat_text_edit.get_text()
-ditem.melee.accuracy_stat = accuracy_stat_text_edit.get_text()
+	ditem.melee.damage_stat = damage_stat_text_edit.get_text()
+	ditem.melee.accuracy_stat = accuracy_stat_text_edit.get_text()
 
 	if UsedSkillTextEdit.get_text() != "":
 		ditem.melee.used_skill = {
@@ -84,26 +84,8 @@ func can_skill_drop(dropped_data: Dictionary):
 	# If all checks pass, return true
 	return true
 
-	func stat_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
-		if dropped_data and dropped_data.has("id"):
-		var stat_id = dropped_data["id"]
-		if not Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(stat_id):
-		print_debug("No stat data found for ID: " + stat_id)
-		return
-		texteditcontrol.set_text(stat_id)
-		else:
-		print_debug("Dropped data does not contain an 'id' key.")
-
-	func can_stat_drop(dropped_data: Dictionary):
-				if not dropped_data or not dropped_data.has("id"):
-				return false
-				return Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(dropped_data["id"])
-
-
 # Set the drop functions on the required skill and skill progression controls
 # This enables them to receive drop data
-		func set_drop_functions():
-				UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)
-				UsedSkillTextEdit.can_drop_function = can_skill_drop
-				accuracy_stat_text_edit.drop_function = stat_drop.bind(accuracy_stat_text_edit)
-				accuracy_stat_text_edit.can_drop_function = can_stat_drop
+func set_drop_functions():
+	UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)
+	UsedSkillTextEdit.can_drop_function = can_skill_drop

--- a/Scripts/ItemMeleeEditor.gd
+++ b/Scripts/ItemMeleeEditor.gd
@@ -9,6 +9,7 @@ extends Control
 @export var UsedSkillTextEdit: HBoxContainer = null
 @export var skill_xp_spin_box: SpinBox = null
 @export var damage_stat_text_edit: HBoxContainer = null
+@export var accuracy_stat_text_edit: HBoxContainer = null
 
 var ditem: DItem = null:
 	set(value):
@@ -16,10 +17,11 @@ var ditem: DItem = null:
 			return
 		ditem = value
 		load_properties()
-
-func _ready():
-	set_drop_functions()
-	damage_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
+	
+			func _ready():
+			set_drop_functions()
+damage_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
+accuracy_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
 
 # Load the properties from the ditem.melee and update the UI elements
 func load_properties() -> void:
@@ -35,14 +37,17 @@ func load_properties() -> void:
 				UsedSkillTextEdit.set_text(ditem.melee.used_skill["skill_id"])
 		if ditem.melee.used_skill.has("xp"):
 				skill_xp_spin_box.value = ditem.melee.used_skill["xp"]
-		if ditem.melee.damage_stat != "":
-				damage_stat_text_edit.set_text(ditem.melee.damage_stat)
+if ditem.melee.damage_stat != "":
+damage_stat_text_edit.set_text(ditem.melee.damage_stat)
+if ditem.melee.accuracy_stat != "":
+accuracy_stat_text_edit.set_text(ditem.melee.accuracy_stat)
 
 # Save the properties from the UI elements back to ditem.melee
 func save_properties() -> void:
 	ditem.melee.damage = int(DamageSpinBox.value)
 	ditem.melee.reach = int(ReachSpinBox.value)
-	ditem.melee.damage_stat = damage_stat_text_edit.get_text()
+ditem.melee.damage_stat = damage_stat_text_edit.get_text()
+ditem.melee.accuracy_stat = accuracy_stat_text_edit.get_text()
 
 	if UsedSkillTextEdit.get_text() != "":
 		ditem.melee.used_skill = {
@@ -77,11 +82,28 @@ func can_skill_drop(dropped_data: Dictionary):
 		return false
 
 	# If all checks pass, return true
-		return true
+	return true
+
+	func stat_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
+		if dropped_data and dropped_data.has("id"):
+		var stat_id = dropped_data["id"]
+		if not Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(stat_id):
+		print_debug("No stat data found for ID: " + stat_id)
+		return
+		texteditcontrol.set_text(stat_id)
+		else:
+		print_debug("Dropped data does not contain an 'id' key.")
+
+	func can_stat_drop(dropped_data: Dictionary):
+				if not dropped_data or not dropped_data.has("id"):
+				return false
+				return Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(dropped_data["id"])
 
 
 # Set the drop functions on the required skill and skill progression controls
 # This enables them to receive drop data
-func set_drop_functions():
-	UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)
-	UsedSkillTextEdit.can_drop_function = can_skill_drop
+		func set_drop_functions():
+				UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)
+				UsedSkillTextEdit.can_drop_function = can_skill_drop
+				accuracy_stat_text_edit.drop_function = stat_drop.bind(accuracy_stat_text_edit)
+				accuracy_stat_text_edit.can_drop_function = can_stat_drop

--- a/Tests/Unit/test_item_melee_editor.gd
+++ b/Tests/Unit/test_item_melee_editor.gd
@@ -10,15 +10,16 @@ func before_all():
 	await get_tree().process_frame
 
 func before_each():
-	my_ditem = DItem.new({
-		"id": "test_melee_item",
-		"Melee": {
-			"damage": 5,
-			"reach": 1,
-			"used_skill": {"skill_id": "bashing", "xp": 1.0},
-			"damage_stat": "strength"
-		}
-	}, null)
+my_ditem = DItem.new({
+"id": "test_melee_item",
+"Melee": {
+"damage": 5,
+"reach": 1,
+"used_skill": {"skill_id": "bashing", "xp": 1.0},
+"damage_stat": "strength",
+"accuracy_stat": "dexterity"
+}
+}, null)
 	editor_instance = melee_editor_scene.instantiate()
 	get_tree().root.add_child(editor_instance)
 	await get_tree().process_frame
@@ -32,11 +33,12 @@ func after_all():
 	Runtimedata.reset()
 
 func test_editor_loads_melee_data():
-	assert_eq(editor_instance.DamageSpinBox.value, 5)
-	assert_eq(editor_instance.ReachSpinBox.value, 1)
-	assert_eq(editor_instance.UsedSkillTextEdit.get_text(), "bashing")
-	assert_eq(editor_instance.skill_xp_spin_box.value, 1.0)
-	assert_eq(editor_instance.damage_stat_text_edit.get_text(), "strength")
+assert_eq(editor_instance.DamageSpinBox.value, 5)
+assert_eq(editor_instance.ReachSpinBox.value, 1)
+assert_eq(editor_instance.UsedSkillTextEdit.get_text(), "bashing")
+assert_eq(editor_instance.skill_xp_spin_box.value, 1.0)
+assert_eq(editor_instance.damage_stat_text_edit.get_text(), "strength")
+assert_eq(editor_instance.accuracy_stat_text_edit.get_text(), "dexterity")
 
 func test_drop_damage_stat_and_save():
 	var dropdata: Dictionary = {
@@ -48,4 +50,16 @@ func test_drop_damage_stat_and_save():
 	editor_instance.damage_stat_text_edit._drop_data(Vector2.ZERO, dropdata)
 	assert_eq(editor_instance.damage_stat_text_edit.get_text(), "dexterity")
 	editor_instance.save_properties()
-	assert_eq(my_ditem.melee.damage_stat, "dexterity")
+assert_eq(my_ditem.melee.damage_stat, "dexterity")
+
+func test_drop_accuracy_stat_and_save():
+var dropdata: Dictionary = {
+"id": "strength",
+"text": "strength",
+"mod_id": "Test",
+"contentType": DMod.ContentType.STATS
+}
+editor_instance.accuracy_stat_text_edit._drop_data(Vector2.ZERO, dropdata)
+assert_eq(editor_instance.accuracy_stat_text_edit.get_text(), "strength")
+editor_instance.save_properties()
+assert_eq(my_ditem.melee.accuracy_stat, "strength")

--- a/Tests/Unit/test_item_melee_editor.gd
+++ b/Tests/Unit/test_item_melee_editor.gd
@@ -10,16 +10,16 @@ func before_all():
 	await get_tree().process_frame
 
 func before_each():
-my_ditem = DItem.new({
-"id": "test_melee_item",
-"Melee": {
-"damage": 5,
-"reach": 1,
-"used_skill": {"skill_id": "bashing", "xp": 1.0},
-"damage_stat": "strength",
-"accuracy_stat": "dexterity"
-}
-}, null)
+	my_ditem = DItem.new({
+		"id": "test_melee_item",
+		"Melee": {
+			"damage": 5,
+			"reach": 1,
+			"used_skill": {"skill_id": "bashing", "xp": 1.0},
+			"damage_stat": "strength",
+			"accuracy_stat": "dexterity"
+		}
+	}, null)
 	editor_instance = melee_editor_scene.instantiate()
 	get_tree().root.add_child(editor_instance)
 	await get_tree().process_frame
@@ -33,12 +33,12 @@ func after_all():
 	Runtimedata.reset()
 
 func test_editor_loads_melee_data():
-assert_eq(editor_instance.DamageSpinBox.value, 5)
-assert_eq(editor_instance.ReachSpinBox.value, 1)
-assert_eq(editor_instance.UsedSkillTextEdit.get_text(), "bashing")
-assert_eq(editor_instance.skill_xp_spin_box.value, 1.0)
-assert_eq(editor_instance.damage_stat_text_edit.get_text(), "strength")
-assert_eq(editor_instance.accuracy_stat_text_edit.get_text(), "dexterity")
+	assert_eq(editor_instance.DamageSpinBox.value, 5)
+	assert_eq(editor_instance.ReachSpinBox.value, 1)
+	assert_eq(editor_instance.UsedSkillTextEdit.get_text(), "bashing")
+	assert_eq(editor_instance.skill_xp_spin_box.value, 1.0)
+	assert_eq(editor_instance.damage_stat_text_edit.get_text(), "strength")
+	assert_eq(editor_instance.accuracy_stat_text_edit.get_text(), "dexterity")
 
 func test_drop_damage_stat_and_save():
 	var dropdata: Dictionary = {
@@ -50,16 +50,16 @@ func test_drop_damage_stat_and_save():
 	editor_instance.damage_stat_text_edit._drop_data(Vector2.ZERO, dropdata)
 	assert_eq(editor_instance.damage_stat_text_edit.get_text(), "dexterity")
 	editor_instance.save_properties()
-assert_eq(my_ditem.melee.damage_stat, "dexterity")
+	assert_eq(my_ditem.melee.damage_stat, "dexterity")
 
 func test_drop_accuracy_stat_and_save():
-var dropdata: Dictionary = {
-"id": "strength",
-"text": "strength",
-"mod_id": "Test",
-"contentType": DMod.ContentType.STATS
-}
-editor_instance.accuracy_stat_text_edit._drop_data(Vector2.ZERO, dropdata)
-assert_eq(editor_instance.accuracy_stat_text_edit.get_text(), "strength")
-editor_instance.save_properties()
-assert_eq(my_ditem.melee.accuracy_stat, "strength")
+	var dropdata: Dictionary = {
+		"id": "strength",
+		"text": "strength",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.STATS
+	}
+	editor_instance.accuracy_stat_text_edit._drop_data(Vector2.ZERO, dropdata)
+	assert_eq(editor_instance.accuracy_stat_text_edit.get_text(), "strength")
+	editor_instance.save_properties()
+	assert_eq(my_ditem.melee.accuracy_stat, "strength")


### PR DESCRIPTION
## Summary
- support accuracy stat for melee weapons in `DItem.gd`
- wire up accuracy stat in combat logic
- expose accuracy stat field in melee item editor
- adjust unit tests for new stat
- add follow-up review task

## Testing
- `godot --headless --import` *(fails: Failed loading resource)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: Parse Error: Identifier "GutUtils" not declared)*

------
https://chatgpt.com/codex/tasks/task_e_6870255d4c7083259de9986e78d22ac0