### PR TITLE
Add maintenance task breakdown

### DIFF
--- a/.project-management/current-prd/tasks-prd-code-refactor.md
+++ b/.project-management/current-prd/tasks-prd-code-refactor.md
@@ -1,0 +1,233 @@
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Defaults
+│   ├── Blocks
+│   ├── Mobs
+│   ├── Player
+│   ├── Projectiles
+│   ├── Shaders
+│   └── Sprites
+├── FeatureList.md
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── README.md
+├── Scenes
+│   ├── ContentManager
+│   ├── GameOver.tscn
+│   ├── InventoryContainerListItem.tscn
+│   ├── InventoryWindow.tscn
+│   ├── LoadingScreen.tscn
+│   ├── Overmap
+│   ├── UI
+│   ├── input_manager.tscn
+│   └── player.tscn
+├── Scripts
+│   ├── AttributesWindow.gd
+│   ├── AttributesWindow.gd.uid
+│   ├── BuildManager.gd
+│   ├── BuildManager.gd.uid
+│   ├── BuildingMenu.gd
+│   ├── BuildingMenu.gd.uid
+│   ├── Camera.gd
+│   ├── Camera.gd.uid
+│   ├── CharacterWindow.gd
+│   ├── CharacterWindow.gd.uid
+│   ├── Chunk.gd
+│   ├── Chunk.gd.uid
+│   ├── ChunkLevel.gd
+│   ├── ChunkLevel.gd.uid
+│   ├── Client.gd
+│   ├── Client.gd.uid
+│   ├── Components
+│   ├── ConstructionGhost.gd
+│   ├── ConstructionGhost.gd.uid
+│   ├── CraftingMenu.gd
+│   ├── CraftingMenu.gd.uid
+│   ├── CtrlInventoryStackedCustom.gd
+│   ├── CtrlInventoryStackedCustom.gd.uid
+│   ├── CtrlInventoryStackedListItem.gd
+│   ├── CtrlInventoryStackedListItem.gd.uid
+│   ├── CtrlInventoryStackedlistHeaderItem.gd
+│   ├── CtrlInventoryStackedlistHeaderItem.gd.uid
+│   ├── Documentation.gd
+│   ├── Documentation.gd.uid
+│   ├── EquipmentSlot.gd
+│   ├── EquipmentSlot.gd.uid
+│   ├── EquippedItem.gd
+│   ├── EquippedItem.gd.uid
+│   ├── EscapeMenu.gd
+│   ├── EscapeMenu.gd.uid
+│   ├── FurnitureBlueprintSpawner.gd
+│   ├── FurnitureBlueprintSpawner.gd.uid
+│   ├── FurnitureBlueprintSrv.gd
+│   ├── FurnitureBlueprintSrv.gd.uid
+│   ├── FurnitureConstructionWindow.gd
+│   ├── FurnitureConstructionWindow.gd.uid
+│   ├── FurniturePhysicsSpawner.gd
+│   ├── FurniturePhysicsSpawner.gd.uid
+│   ├── FurniturePhysicsSrv.gd
+│   ├── FurniturePhysicsSrv.gd.uid
+│   ├── FurnitureStaticSpawner.gd
+│   ├── FurnitureStaticSpawner.gd.uid
+│   ├── FurnitureStaticSrv.gd
+│   ├── FurnitureStaticSrv.gd.uid
+│   ├── FurnitureWindow.gd
+│   ├── FurnitureWindow.gd.uid
+│   ├── GameOver.gd
+│   ├── GameOver.gd.uid
+│   ├── Gamedata
+│   ├── HeldItem.gd
+│   ├── HeldItem.gd.uid
+│   ├── Helper
+│   ├── Helper.gd
+│   ├── Helper.gd.uid
+│   ├── InventoryContainerListItem.gd
+│   ├── InventoryContainerListItem.gd.uid
+│   ├── InventoryWindow.gd
+│   ├── InventoryWindow.gd.uid
+│   ├── ItemAmmoEditor.gd
+│   ├── ItemAmmoEditor.gd.uid
+│   ├── ItemCraftEditor.gd
+│   ├── ItemCraftEditor.gd.uid
+│   ├── ItemDetector.gd
+│   ├── ItemDetector.gd.uid
+│   ├── ItemEditor.gd
+│   ├── ItemEditor.gd.uid
+│   ├── ItemFoodEditor.gd
+│   ├── ItemFoodEditor.gd.uid
+│   ├── ItemMagazineEditor.gd
+│   ├── ItemMagazineEditor.gd.uid
+│   ├── ItemMedicalEditor.gd
+│   ├── ItemMedicalEditor.gd.uid
+│   ├── ItemMeleeEditor.gd
+│   ├── ItemMeleeEditor.gd.uid
+│   ├── ItemRangedEditor.gd
+│   ├── ItemRangedEditor.gd.uid
+│   ├── ItemToolEditor.gd
+│   ├── ItemToolEditor.gd.uid
+│   ├── ItemWearableEditor.gd
+│   ├── ItemWearableEditor.gd.uid
+│   ├── LoadingScreen.gd
+│   ├── LoadingScreen.gd.uid
+│   ├── Mob
+│   ├── NonHUDclick.gd
+│   ├── NonHUDclick.gd.uid
+│   ├── OvermapGrid.gd
+│   ├── OvermapGrid.gd.uid
+│   ├── PlayerAttribute.gd
+│   ├── PlayerAttribute.gd.uid
+│   ├── PlayerShooting.gd
+│   ├── PlayerShooting.gd.uid
+│   ├── QuestTrackerUI.gd
+│   ├── QuestTrackerUI.gd.uid
+│   ├── QuestWindow.gd
+│   ├── QuestWindow.gd.uid
+│   ├── Runtimedata
+│   ├── WearableSlot.gd
+│   ├── WearableSlot.gd.uid
+│   ├── bullet.gd
+│   ├── bullet.gd.uid
+│   ├── container.gd
+│   ├── container.gd.uid
+│   ├── crafting_recipes_manager.gd
+│   ├── crafting_recipes_manager.gd.uid
+│   ├── gamedata.gd
+│   ├── gamedata.gd.uid
+│   ├── general.gd
+│   ├── general.gd.uid
+│   ├── hud.gd
+│   ├── hud.gd.uid
+│   ├── input_manager.gd
+│   ├── input_manager.gd.uid
+│   ├── item_manager.gd
+│   ├── item_manager.gd.uid
+│   ├── player.gd
+│   ├── player.gd.uid
+│   ├── runtimedata.gd
+│   ├── runtimedata.gd.uid
+│   ├── scene_selector.gd
+│   ├── scene_selector.gd.uid
+│   ├── target_manager.gd
+│   ├── target_manager.gd.uid
+│   ├── weapon.gd
+│   └── weapon.gd.uid
+├── Shaders
+│   ├── HideAbovePlayer.gdshader
+│   ├── HideAbovePlayer.gdshader.uid
+│   ├── HideAbovePlayerShadow.gdshader
+│   └── HideAbovePlayerShadow.gdshader.uid
+├── Tests
+│   └── Unit
+├── day_night.gd
+├── day_night.gd.uid
+├── day_night.tscn
+├── documentation.tscn
+├── entity_manager.gd
+├── entity_manager.gd.uid
+├── export_presets.cfg
+├── front_light.gd
+├── front_light.gd.uid
+├── front_light.tscn
+├── hud.tscn
+├── icon.svg
+├── icon.svg.import
+├── level_generation.tscn
+├── override.cfg
+├── project.godot
+├── scene_selector.tscn
+├── spot_light_3d.tscn
+├── spot_light_3d_2.tscn
+├── test_environment.gd
+├── test_environment.gd.uid
+├── test_environment.tscn
+└── torso.aseprite
+
+21 directories, 167 files
+```
+\n## Relevant Files
+\n### Proposed New Files
+- `Scripts/Logger.gd` - Centralized helper for logging across game scripts.
+- `/Tests/Unit/test_logger.gd` - Unit tests for `Logger.gd`.
+
+### Existing Files Modified
+- `Scripts/EquippedItem.gd` - Refactor weapon handling and add comments.
+- `Scripts/BuildManager.gd` - Simplify build state management.
+- `Scripts/PlayerShooting.gd` - Streamline reload logic and integrate with BuildManager.
+- `Scenes/ContentManager/Scripts/*.gd` - Replace direct `print()` calls with `Logger` usage.
+- `Scripts/general.gd` - Document functions and cleanup naming.
+- `LevelGenerator.gd` - Reduce complexity in chunk processing functions.
+- `LevelManager.gd` - Clarify visibility update logic.
+
+### Files To Remove
+- None
+
+### Notes
+- Unit tests should typically be placed in `/Tests/Unit/`.
+\n## Tasks
+- [ ] 1.0 Refactor `EquippedItem.gd`
+  - [ ] 1.1 Identify repeated logic and extract helper methods
+  - [ ] 1.2 Document public functions with comments
+  - [ ] 1.3 Break up large functions like `perform_ranged_attack`
+  - [ ] 1.4 Verify behavior with existing tests
+- [ ] 2.0 Simplify build and shooting interaction
+  - [ ] 2.1 Review `BuildManager.gd` and `PlayerShooting.gd` reload logic
+  - [ ] 2.2 Consolidate reload checks into a single method
+  - [ ] 2.3 Ensure cancelling building restores shooting permissions
+- [ ] 3.0 Standardize logging
+  - [ ] 3.1 Create `Logger.gd` with `info`, `debug`, and `error` methods
+  - [ ] 3.2 Replace all `print` and `print_debug` calls in ContentManager scripts
+  - [ ] 3.3 Add unit tests for `Logger` output
+- [ ] 4.0 Document and clean up `general.gd`
+  - [ ] 4.1 Add docstrings for each function
+  - [ ] 4.2 Remove unused variables and clarify names
+- [ ] 5.0 Simplify chunk loading
+  - [ ] 5.1 Refactor `LevelGenerator.gd` queue processing
+  - [ ] 5.2 Clarify chunk visibility updates in `LevelManager.gd`
+  - [ ] 5.3 Add comments and early returns to improve readability

--- a/.project-management/current-prd/tasks-prd-code-refactor.md
+++ b/.project-management/current-prd/tasks-prd-code-refactor.md
@@ -192,18 +192,9 @@
 21 directories, 167 files
 ```
 \n## Relevant Files
-\n### Proposed New Files
-- `Scripts/Logger.gd` - Centralized helper for logging across game scripts.
-- `/Tests/Unit/test_logger.gd` - Unit tests for `Logger.gd`.
 
 ### Existing Files Modified
-- `Scripts/EquippedItem.gd` - Refactor weapon handling and add comments.
-- `Scripts/BuildManager.gd` - Simplify build state management.
-- `Scripts/PlayerShooting.gd` - Streamline reload logic and integrate with BuildManager.
-- `Scenes/ContentManager/Scripts/*.gd` - Replace direct `print()` calls with `Logger` usage.
 - `Scripts/general.gd` - Document functions and cleanup naming.
-- `LevelGenerator.gd` - Reduce complexity in chunk processing functions.
-- `LevelManager.gd` - Clarify visibility update logic.
 
 ### Files To Remove
 - None
@@ -211,23 +202,6 @@
 ### Notes
 - Unit tests should typically be placed in `/Tests/Unit/`.
 \n## Tasks
-- [ ] 1.0 Refactor `EquippedItem.gd`
-  - [ ] 1.1 Identify repeated logic and extract helper methods
-  - [ ] 1.2 Document public functions with comments
-  - [ ] 1.3 Break up large functions like `perform_ranged_attack`
-  - [ ] 1.4 Verify behavior with existing tests
-- [ ] 2.0 Simplify build and shooting interaction
-  - [ ] 2.1 Review `BuildManager.gd` and `PlayerShooting.gd` reload logic
-  - [ ] 2.2 Consolidate reload checks into a single method
-  - [ ] 2.3 Ensure cancelling building restores shooting permissions
-- [ ] 3.0 Standardize logging
-  - [ ] 3.1 Create `Logger.gd` with `info`, `debug`, and `error` methods
-  - [ ] 3.2 Replace all `print` and `print_debug` calls in ContentManager scripts
-  - [ ] 3.3 Add unit tests for `Logger` output
-- [ ] 4.0 Document and clean up `general.gd`
-  - [ ] 4.1 Add docstrings for each function
-  - [ ] 4.2 Remove unused variables and clarify names
-- [ ] 5.0 Simplify chunk loading
-  - [ ] 5.1 Refactor `LevelGenerator.gd` queue processing
-  - [ ] 5.2 Clarify chunk visibility updates in `LevelManager.gd`
-  - [ ] 5.3 Add comments and early returns to improve readability
+- [ ] 1.0 Document and clean up `general.gd`
+  - [ ] 1.1 Add docstrings for each function
+  - [ ] 1.2 Remove unused variables and clarify names


### PR DESCRIPTION
## Summary
- add maintenance task list for upcoming refactor

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_687172796ee4832594f1d1e0d46b550b