### PR TITLE
Implement documentation and cleanup tasks

### DIFF
--- a/.project-management/current-prd/tasks-prd-code-refactor.md
+++ b/.project-management/current-prd/tasks-prd-code-refactor.md
@@ -195,6 +195,9 @@
 
 ### Existing Files Modified
 - `Scripts/general.gd` - Document functions and cleanup naming.
+- `Scripts/EquippedItem.gd` - Updated variable references and indentation.
+- `Scripts/NonHUDclick.gd` - Updated variable references.
+- `Scripts/Mob/Mob.gd` - Updated reference to shared collision shape.
 
 ### Files To Remove
 - None
@@ -202,6 +205,6 @@
 ### Notes
 - Unit tests should typically be placed in `/Tests/Unit/`.
 \n## Tasks
-- [ ] 1.0 Document and clean up `general.gd`
-  - [ ] 1.1 Add docstrings for each function
-  - [ ] 1.2 Remove unused variables and clarify names
+- [x] 1.0 Document and clean up `general.gd`
+	- [x] 1.1 Add docstrings for each function
+	- [x] 1.2 Remove unused variables and clarify names

--- a/Scripts/EquippedItem.gd
+++ b/Scripts/EquippedItem.gd
@@ -90,9 +90,9 @@ func can_fire_weapon() -> bool:
 	if not equipped_item:
 		return false
 	if equipped_item.get_property("Melee") != null:
-		return General.is_mouse_outside_HUD and not General.is_action_in_progress and equipped_item and not in_cooldown
+		return General.is_mouse_outside_hud and not General.is_action_in_progress and equipped_item and not in_cooldown
 	if equipped_item.get_property("Ranged") != null:
-		return General.is_mouse_outside_HUD and not General.is_action_in_progress and General.is_allowed_to_shoot and equipped_item and not in_cooldown and (get_current_ammo() > 0 or not requires_ammo())
+		return General.is_mouse_outside_hud and not General.is_action_in_progress and General.is_allowed_to_shoot and equipped_item and not in_cooldown and (get_current_ammo() > 0 or not requires_ammo())
 	return false
 
 

--- a/Scripts/Mob/Mob.gd
+++ b/Scripts/Mob/Mob.gd
@@ -107,7 +107,7 @@ func create_detection():
 # Create and configure CollisionShape3D
 func create_collision_shape():
 	collision_shape_3d = CollisionShape3D.new()
-	collision_shape_3d.shape = General.shared_shape
+	collision_shape_3d.shape = General.shared_collision_shape
 	add_child.call_deferred(collision_shape_3d)
 
 

--- a/Scripts/NonHUDclick.gd
+++ b/Scripts/NonHUDclick.gd
@@ -2,8 +2,8 @@ extends Control
 
 
 func _on_mouse_entered():
-	General.is_mouse_outside_HUD = true
+	General.is_mouse_outside_hud = true
 
 
 func _on_mouse_exited():
-	General.is_mouse_outside_HUD = false
+	General.is_mouse_outside_hud = false

--- a/Scripts/general.gd
+++ b/Scripts/general.gd
@@ -1,7 +1,7 @@
 extends Node
 
 # Existing variables
-var is_mouse_outside_HUD = false
+var is_mouse_outside_hud = false
 var is_allowed_to_shoot = true
 
 # For controlling the player actions
@@ -11,28 +11,19 @@ var action_complete_callback: Callable  # Use Callable to store the function ref
 signal start_timer_progressbar(time_left: float)
 
 # Shared shape for mobs
-var shared_shape = BoxShape3D.new()
+var shared_collision_shape = BoxShape3D.new()
 
+## Initializes the action timer and connects signals.
 func _ready():
 	# Initialize the timer
 	action_timer = Timer.new()
 	action_timer.timeout.connect(_on_action_timer_timeout)
 	add_child(action_timer)
 	start_timer_progressbar.connect(Helper.signal_broker.on_start_timer_progressbar)
-	shared_shape.size = Vector3(0.35, 0.35, 0.35)
+	shared_collision_shape.size = Vector3(0.35, 0.35, 0.35)
 
+## Starts a timed action and runs `callback` when finished.
 
-# Function to start an action
-# Usage example: 
-	# This example will call the 'reload_weapon" function in self after the timer is complete
-	# var reload_callable = Callable(self, "reload_weapon").bind(item, specific_magazine)
-	# General.start_action(reload_time, reload_callable)
-# Usage example using an inline callable:
-	# This example will call the 'myfunc' callable after the start_action timer runs out
-	# var myfunc: Callable = func (itemgroup_id):
-	#	 var ditemgroup: DItemgroup = Gamedata.mods.by_id("Core").itemgroups.by_id(itemgroup_id)
-	#	 ditemgroup.remove_item_by_id(id)
-	# General.start_action(reload_time, myfunc)
 func start_action(duration: float, callback: Callable):
 	if not is_action_in_progress:
 		is_action_in_progress = true
@@ -43,7 +34,7 @@ func start_action(duration: float, callback: Callable):
 	else:
 		print_debug("Another action is currently in progress.")
 
-# Function called when the action timer runs out
+## Handles the completion of a timed action.
 func _on_action_timer_timeout():
 	is_action_in_progress = false
 	# Call the callback function if it exists
@@ -56,7 +47,7 @@ func _on_action_timer_timeout():
 	# Code to handle the completion of the action
 
 
-# Converts a string to a Vector2. If it's already a Vector2, it remains a Vector2
+## Converts a string in the form "(x, y)" to a Vector2. Returns Vector2.ZERO if invalid.
 static func string_to_vector2(input: Variant) -> Vector2:
 	# If input is already a Vector2, return it as is
 	if input is Vector2:

--- a/Scripts/general.gd
+++ b/Scripts/general.gd
@@ -22,8 +22,17 @@ func _ready():
 	start_timer_progressbar.connect(Helper.signal_broker.on_start_timer_progressbar)
 	shared_collision_shape.size = Vector3(0.35, 0.35, 0.35)
 
-## Starts a timed action and runs `callback` when finished.
-
+# Function to start an action
+# Usage example: 
+	# This example will call the 'reload_weapon" function in self after the timer is complete
+	# var reload_callable = Callable(self, "reload_weapon").bind(item, specific_magazine)
+	# General.start_action(reload_time, reload_callable)
+# Usage example using an inline callable:
+	# This example will call the 'myfunc' callable after the start_action timer runs out
+	# var myfunc: Callable = func (itemgroup_id):
+	#	 var ditemgroup: DItemgroup = Gamedata.mods.by_id("Core").itemgroups.by_id(itemgroup_id)
+	#	 ditemgroup.remove_item_by_id(id)
+	# General.start_action(reload_time, myfunc)
 func start_action(duration: float, callback: Callable):
 	if not is_action_in_progress:
 		is_action_in_progress = true


### PR DESCRIPTION
## Summary
- document general singleton functions and rename some variables
- update references in `EquippedItem.gd`, `NonHUDclick.gd`, and `Mob.gd`
- mark tasks complete in project management docs
- convert indentation to tabs where needed

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_6872a69726b883259418a3553d1c278e