### PR TITLE
Refine readability refactor tasks

### DIFF
--- a/project-management/current-prd/tasks-prd-readability-refactor.md
+++ b/project-management/current-prd/tasks-prd-readability-refactor.md
@@ -53,25 +53,6 @@
 
 14 directories, 33 files
 ```
-## Relevant Files
-- Scripts/player.gd
-- Scripts/item_manager.gd
-- Scripts/BuildManager.gd
-- Scripts/hud.gd
-- Scripts/Helper/SignalBroker/signal_broker.gd
-- Tests/Unit/test_player.gd
-- Tests/Unit/test_item_manager.gd
-
-### Proposed New Files
-- Scripts/Helper/inventory_utils.gd - Utility functions extracted from item_manager.gd.
-- Tests/Unit/test_inventory_utils.gd - Unit tests for inventory_utils.gd.
-
-### Existing Files Modified
-- Scripts/player.gd - Split large functions and organize code.
-- Scripts/item_manager.gd - Move helper logic to inventory_utils.gd and clean up naming.
-- Scripts/BuildManager.gd - Consolidate ghost update logic and add comments.
-- Scripts/hud.gd - Extract repetitive UI toggling into helper methods.
-- Scripts/Helper/SignalBroker/signal_broker.gd - Add documentation comments for clarity.
 
 ### Files To Remove
 - None
@@ -80,28 +61,9 @@
 - Unit tests should typically be placed in `/Tests/Unit/`.
 
 ## Tasks
-- [ ] 1.0 Modularize `player.gd` for readability
-    - [ ] 1.1 Split large functions into smaller ones
-    - [ ] 1.2 Group constants and variables logically
-    - [ ] 1.3 Add section comments and docstrings
-    - [ ] 1.4 Update unit tests for player logic
-- [ ] 2.0 Extract inventory helper functions and refactor `item_manager.gd`
-    - [ ] 2.1 Create `inventory_utils.gd` with common functions
-    - [ ] 2.2 Refactor `item_manager.gd` to use the new helper
-    - [ ] 2.3 Write unit tests for `inventory_utils.gd`
-    - [ ] 2.4 Update item manager tests
-- [ ] 3.0 Consolidate repeated UI logic in BuildManager and HUD scripts
-    - [ ] 3.1 Identify duplicate toggling logic
-    - [ ] 3.2 Add helper methods for UI toggles
-    - [ ] 3.3 Replace duplicated code in BuildManager.gd and hud.gd
-    - [ ] 3.4 Verify UI behavior via tests or manual checks
 - [ ] 4.0 Standardize comments and naming across selected scripts
     - [ ] 4.1 Review variable and method names for consistency
     - [ ] 4.2 Update comments to follow Godot guidelines
     - [ ] 4.3 Remove outdated or unused code
-- [ ] 5.0 Document signals in `signal_broker.gd`
-    - [ ] 5.1 Add documentation comments describing each signal
-    - [ ] 5.2 Ensure emits and connects match documented signals
-    - [ ] 5.3 Add tests verifying important signal interactions
 
 *End of document*

--- a/project-management/current-prd/tasks-prd-readability-refactor.md
+++ b/project-management/current-prd/tasks-prd-readability-refactor.md
@@ -1,0 +1,107 @@
+## Selected maintenance goal
+- Refactor for Readability & Maintainability
+
+## Pre-Feature Development Project Tree
+```
+./
+├── AGENTS.md
+├── Assets/
+├── Defaults/
+├── Documentation/
+├── FeatureList.md
+├── Images/
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── Media/
+├── Mods/
+├── README.md
+├── Scenes/
+├── Scripts/
+├── Shaders/
+├── Sounds/
+├── Tests/
+├── Textures/
+├── day_night.gd
+├── day_night.gd.uid
+├── day_night.tscn
+├── documentation.tscn
+├── entity_manager.gd
+├── entity_manager.gd.uid
+├── export_presets.cfg
+├── front_light.gd
+├── front_light.gd.uid
+├── front_light.tscn
+├── hud.tscn
+├── icon.svg
+├── icon.svg.import
+├── level_generation.tscn
+├── override.cfg
+├── project-management/
+├── project.godot
+├── scene_selector.tscn
+├── spot_light_3d.tscn
+├── spot_light_3d_2.tscn
+├── test_environment.gd
+├── test_environment.gd.uid
+├── test_environment.tscn
+└── torso.aseprite
+
+14 directories, 33 files
+```
+## Relevant Files
+- Scripts/player.gd
+- Scripts/item_manager.gd
+- Scripts/BuildManager.gd
+- Scripts/hud.gd
+- Scripts/Helper/SignalBroker/signal_broker.gd
+- Tests/Unit/test_player.gd
+- Tests/Unit/test_item_manager.gd
+
+### Proposed New Files
+- Scripts/Helper/inventory_utils.gd - Utility functions extracted from item_manager.gd.
+- Tests/Unit/test_inventory_utils.gd - Unit tests for inventory_utils.gd.
+
+### Existing Files Modified
+- Scripts/player.gd - Split large functions and organize code.
+- Scripts/item_manager.gd - Move helper logic to inventory_utils.gd and clean up naming.
+- Scripts/BuildManager.gd - Consolidate ghost update logic and add comments.
+- Scripts/hud.gd - Extract repetitive UI toggling into helper methods.
+- Scripts/Helper/SignalBroker/signal_broker.gd - Add documentation comments for clarity.
+
+### Files To Remove
+- None
+
+### Notes
+- Unit tests should typically be placed in `/Tests/Unit/`.
+
+## Tasks
+- [ ] 1.0 Modularize `player.gd` for readability
+    - [ ] 1.1 Split large functions into smaller ones
+    - [ ] 1.2 Group constants and variables logically
+    - [ ] 1.3 Add section comments and docstrings
+    - [ ] 1.4 Update unit tests for player logic
+- [ ] 2.0 Extract inventory helper functions and refactor `item_manager.gd`
+    - [ ] 2.1 Create `inventory_utils.gd` with common functions
+    - [ ] 2.2 Refactor `item_manager.gd` to use the new helper
+    - [ ] 2.3 Write unit tests for `inventory_utils.gd`
+    - [ ] 2.4 Update item manager tests
+- [ ] 3.0 Consolidate repeated UI logic in BuildManager and HUD scripts
+    - [ ] 3.1 Identify duplicate toggling logic
+    - [ ] 3.2 Add helper methods for UI toggles
+    - [ ] 3.3 Replace duplicated code in BuildManager.gd and hud.gd
+    - [ ] 3.4 Verify UI behavior via tests or manual checks
+- [ ] 4.0 Standardize comments and naming across selected scripts
+    - [ ] 4.1 Review variable and method names for consistency
+    - [ ] 4.2 Update comments to follow Godot guidelines
+    - [ ] 4.3 Remove outdated or unused code
+- [ ] 5.0 Document signals in `signal_broker.gd`
+    - [ ] 5.1 Add documentation comments describing each signal
+    - [ ] 5.2 Ensure emits and connects match documented signals
+    - [ ] 5.3 Add tests verifying important signal interactions
+
+*End of document*


### PR DESCRIPTION
## Summary
- trim project tree output for readability
- add detailed sub-tasks for refactor plan

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_6873f122a43c8325a7661d77728fcc89