### PR TITLE
Update signal docs and usage

### DIFF
--- a/.project-management/current-prd/tasks-main-gameplay-logic-refactoring.md
+++ b/.project-management/current-prd/tasks-main-gameplay-logic-refactoring.md
@@ -50,10 +50,18 @@
 
 ## Relevant Files
 - `Scripts/Helper/SignalBroker/signal_broker.gd`
+- `Documentation/Game_development/signal_conventions.md`
+- `Scripts/hud.gd`
+- `Scripts/LoadingScreen.gd`
+- `Scripts/input_manager.gd`
 
 
 ### Existing Files Modified
 - `Scripts/Helper/SignalBroker/signal_broker.gd` - Updated signal definitions.
+- `Documentation/Game_development/signal_conventions.md` - Document broker usage and conventions.
+- `Scripts/hud.gd` - Connect and disconnect signals in proper callbacks.
+- `Scripts/LoadingScreen.gd` - Connect broker signals in `_ready` and disconnect in `_exit_tree`.
+- `Scripts/input_manager.gd` - Use callable for inventory visibility and disconnect in `_exit_tree`.
 
 ### Files To Remove
 - None
@@ -62,10 +70,10 @@
 - Unit tests should typically be placed in `/Tests/Unit/`.
 
 ## Tasks
-- [ ] **4.0 Standardize signal usage across gameplay scripts**
-  - [ ] **4.1 Review signals in `signal_broker.gd` and document expected patterns**
-  - [ ] **4.2 Update gameplay scripts to use broker signals and typed connections**
-  - [ ] **4.3 Document signal conventions in `Documentation/Game_development/signal_conventions.md`**
-  - [ ] **4.4 Ensure connections are made in `_ready` and cleared in `_exit_tree`**
+- [x] **4.0 Standardize signal usage across gameplay scripts**
+  - [x] **4.1 Review signals in `signal_broker.gd` and document expected patterns**
+  - [x] **4.2 Update gameplay scripts to use broker signals and typed connections**
+  - [x] **4.3 Document signal conventions in `Documentation/Game_development/signal_conventions.md`**
+  - [x] **4.4 Ensure connections are made in `_ready` and cleared in `_exit_tree`**
 
 *End of document*

--- a/Documentation/Game_development/signal_conventions.md
+++ b/Documentation/Game_development/signal_conventions.md
@@ -1,0 +1,39 @@
+# Signal conventions
+
+This document explains how gameplay scripts communicate via `SignalBroker`.
+
+## Overview
+`SignalBroker` (located at `Scripts/Helper/SignalBroker/signal_broker.gd`) exposes a collection of typed signals used across the project.  Scripts obtain the broker through `Helper.signal_broker` and connect to the required signals.  Connections should be made in `_ready` and cleaned up in `_exit_tree`.
+
+- Declare connections in the `_ready` function using typed connections.
+- Disconnect signals in `_exit_tree` to avoid dangling connections.
+- Some signals are generated dynamically with `SignalFactory`.  These helper methods return a `Signal` instance scoped by a unique key, for example `item_was_equipped_to_slot(slot_index)`.
+
+Example:
+```gdscript
+func _ready() -> void:
+    Helper.signal_broker.game_started.connect(_on_game_started)
+
+func _exit_tree() -> void:
+    Helper.signal_broker.game_started.disconnect(_on_game_started)
+```
+
+## Common signals
+| Signal | Purpose |
+| --- | --- |
+| `hud_start_progressbar(time_left: float)` | Tell the HUD to display a progress bar for `time_left` seconds. |
+| `inventory_window_visibility_changed(window: Control)` | Emitted when the inventory window is shown or hidden. |
+| `build_window_visibility_changed(window: Control)` | Emitted when the build menu is shown or hidden. |
+| `items_were_used(items: Array[InventoryItem])` | Sent after one or more items are consumed. |
+| `wearable_was_equipped(item: InventoryItem, slot: Control)` | A wearable item was equipped into a slot. |
+| `container_entered_proximity(container: Node3D)` | The player approached a container. |
+| `player_stat_changed(player: Player)` | A player stat changed, e.g. health or stamina. |
+| `game_started()` / `game_loaded()` | Emitted when a new game begins or a save is loaded. |
+
+When a signal needs to be scoped to a specific slot or entity, use the factory helpers.  For example:
+```gdscript
+var sig := Helper.signal_broker.item_was_equipped_to_slot(0)
+sig.connect(on_slot_equipped)
+```
+
+By adhering to these conventions gameplay scripts can remain decoupled while still responding to game events.

--- a/Scripts/Helper/SignalBroker/signal_broker.gd
+++ b/Scripts/Helper/SignalBroker/signal_broker.gd
@@ -5,6 +5,10 @@ extends Node
 # It is indended to aid in communication between nodes during gameplay
 # The most significant use case is communication between game entities and the hud
 # This script is loaded by Helper.gd and is accessible as Helper.signal_broker
+# Gameplay scripts should connect to these signals in `_ready` using typed
+# connections and disconnect in `_exit_tree`.  Signals that must be scoped to a
+# specific key are provided as helper functions returning a `Signal` from
+# `SignalFactory`.
 
 # Signalled to the hud to start a progressbar
 signal hud_start_progressbar(time_left: float)

--- a/Scripts/LoadingScreen.gd
+++ b/Scripts/LoadingScreen.gd
@@ -5,11 +5,17 @@ extends Control
 @export var sub_label: Label
 
 
-func _init():
+func _ready():
 	Helper.signal_broker.initial_chunks_generated.connect(_on_initial_chunks_generated)
 	Helper.signal_broker.game_started.connect(update_sub_text.bind("Creating new save"))
 	Helper.signal_broker.game_loaded.connect(update_sub_text.bind("Loading saved game"))
 	Helper.signal_broker.player_spawned.connect(_on_player_spawned)
+
+func _exit_tree() -> void:
+	Helper.signal_broker.initial_chunks_generated.disconnect(_on_initial_chunks_generated)
+	Helper.signal_broker.game_started.disconnect(update_sub_text.bind("Creating new save"))
+	Helper.signal_broker.game_loaded.disconnect(update_sub_text.bind("Loading saved game"))
+	Helper.signal_broker.player_spawned.disconnect(_on_player_spawned)
 	
 func _on_initial_chunks_generated():
 	visible = false

--- a/Scripts/hud.gd
+++ b/Scripts/hud.gd
@@ -36,18 +36,22 @@ func _process(_delta):
 	if is_progress_bar_active:
 		update_progress_bar()
 
-func _init():
-	# If some node wants to start a progressbar, they will emit a signal trough the broker
+func _ready():
+	# Connect gameplay signals when ready
 	Helper.signal_broker.hud_start_progressbar.connect(start_progress_bar)
-	# We let the signal broker forward the change in visibility so other nodes can respond
 	Helper.time_helper.minute_passed.connect(_on_minute_passed)
 	Helper.signal_broker.player_stamina_changed.connect(_on_player_update_stamina_hud)
 	Helper.signal_broker.player_ammo_changed.connect(_on_shooting_ammo_changed)
-
-func _ready():
 	var buildmenu = get_node(building_menu)
-	buildmenu.visibility_changed.connect(\
+	buildmenu.visibility_changed.connect(
 	Helper.signal_broker.on_build_menu_visibility_changed.bind(buildmenu))
+
+func _exit_tree() -> void:
+	Helper.signal_broker.hud_start_progressbar.disconnect(start_progress_bar)
+	Helper.time_helper.minute_passed.disconnect(_on_minute_passed)
+	Helper.signal_broker.player_stamina_changed.disconnect(_on_player_update_stamina_hud)
+	Helper.signal_broker.player_ammo_changed.disconnect(_on_shooting_ammo_changed)
+
 
 func update_progress_bar():
 	var progressBarNode = get_node(progress_bar_filling)

--- a/Scripts/input_manager.gd
+++ b/Scripts/input_manager.gd
@@ -6,9 +6,14 @@ extends Node
 # game state, merely mapping input to signal
 
 var is_inventory_open: bool
+var _inv_visibility_callable: Callable = func(inventory: Control):
+		is_inventory_open = inventory.visible
 
-func _init():
-	Helper.signal_broker.inventory_window_visibility_changed.connect(func(inventory: Control): is_inventory_open = inventory.visible)
+func _ready():
+	Helper.signal_broker.inventory_window_visibility_changed.connect(_inv_visibility_callable)
+
+func _exit_tree() -> void:
+	Helper.signal_broker.inventory_window_visibility_changed.disconnect(_inv_visibility_callable)
 
 func _process(_delta: float) -> void:
 	process_mouse_press()


### PR DESCRIPTION
## Summary
- document typed signal patterns in signal_conventions.md
- connect/disconnect broker signals inside _ready/_exit_tree
- update HUD, LoadingScreen and input manager to follow pattern
- mark signal refactor tasks complete

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_6873f2216e6c832581546c4bcfc590ed