### PR TITLE
Implement build ghost visibility logic

### DIFF
--- a/.project-management/current-prd/tasks-prd-build-ghost-visibility.md
+++ b/.project-management/current-prd/tasks-prd-build-ghost-visibility.md
@@ -24,22 +24,22 @@ $(cat /tmp/project_tree.txt)
 - Changing selection in BuildingMenu should update the ghost without closing the menu.
 
 ## Tasks
-- [ ] **1.0 Investigate Build Ghost Initialization**
-  - [ ] 1.1 Review `level_generation.tscn` for default visibility of `ConstructionGhost`.
-  - [ ] 1.2 Trace signal connections in `BuildManager.gd` and `BuildingMenu.gd` to understand when `start_building()` runs.
-  - [ ] 1.3 Verify that the ghost stays hidden on first open because no construction choice event fires.
+- [x] **1.0 Investigate Build Ghost Initialization**
+  - [x] 1.1 Review `level_generation.tscn` for default visibility of `ConstructionGhost`.
+  - [x] 1.2 Trace signal connections in `BuildManager.gd` and `BuildingMenu.gd` to understand when `start_building()` runs.
+  - [x] 1.3 Verify that the ghost stays hidden on first open because no construction choice event fires.
 - [ ] **2.0 Fix Ghost Visibility on Menu Open**
-  - [ ] 2.1 Add a `get_selected_type_and_choice()` method in `BuildingMenu.gd` to return the current option.
-  - [ ] 2.2 Update `BuildManager.gd` to call this method when the build menu opens and no build session is active.
-  - [ ] 2.3 Ensure `start_building()` sets `construction_ghost.visible` and positions it at the default location.
-  - [ ] 2.4 Update `set_building_state()` to handle visibility toggles when closing the menu.
+  - [c] 2.1 Add a `get_selected_type_and_choice()` method in `BuildingMenu.gd` to return the current option.
+  - [c] 2.2 Update `BuildManager.gd` to call this method when the build menu opens and no build session is active.
+  - [c] 2.3 Ensure `start_building()` sets `construction_ghost.visible` and positions it at the default location.
+  - [c] 2.4 Update `set_building_state()` to handle visibility toggles when closing the menu.
 - [ ] **3.0 Update Ghost When Block Selection Changes**
   - [ ] 3.1 Keep `_on_hud_construction_chosen()` connected to BuildingMenu selection events.
   - [ ] 3.2 Ensure `update_construction_ghost()` immediately changes the ghost mesh/material while the menu remains open.
 - [ ] **4.0 Add Debug Logging**
-  - [ ] 4.1 Insert `print_debug()` statements in `BuildManager.gd` around ghost initialization and visibility changes.
-  - [ ] 4.2 Insert similar debug logs in `ConstructionGhost.gd` when visibility or rotation changes.
+  - [c] 4.1 Insert `print_debug()` statements in `BuildManager.gd` around ghost initialization and visibility changes.
+  - [c] 4.2 Insert similar debug logs in `ConstructionGhost.gd` when visibility or rotation changes.
 - [ ] **5.0 Create Unit Tests for Visibility Logic**
-  - [ ] 5.1 Write `test_build_ghost_visibility.gd` using GUT to confirm the ghost appears on first menu open.
-  - [ ] 5.2 Add a test that changes the selected block and verifies the ghost updates accordingly.
+  - [c] 5.1 Write `test_build_ghost_visibility.gd` using GUT to confirm the ghost appears on first menu open.
+  - [c] 5.2 Add a test that changes the selected block and verifies the ghost updates accordingly.
 *End of document*

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -41,6 +41,9 @@ func _on_hud_construction_chosen(type: String, choice: String):
 func start_building():
 	is_building = true
 	General.is_allowed_to_shoot = false
+	construction_ghost.visible = true
+	construction_ghost.reset_to_default()
+	print_debug("Start building: type = ", construction_type, ", choice = ", construction_choice)
 
 
 # Connects from the ConstructionGhost.gd script. 
@@ -108,16 +111,25 @@ func calculate_local_position(global_pos: Vector3, chunk_pos: Vector3) -> Vector
 	return Vector3(local_x, global_pos.y, local_z)
 
 func _on_build_menu_visibility_change(buildmenu):
-	if !is_building:
-		return
-	# Update construction ghost visibility based on build menu visibility
-	set_building_state(buildmenu.is_visible())
+	print_debug("Build menu visibility changed: ", buildmenu.is_visible())
+	if buildmenu.is_visible():
+		if !is_building:
+			var selection: Dictionary = buildmenu.get_selected_type_and_choice()
+			construction_type = selection.type
+			construction_choice = selection.choice
+			update_construction_ghost()
+			start_building()
+		else:
+			set_building_state(true)
+	else:
+		set_building_state(false)
 
 func set_building_state(isvisible: bool):
 	construction_ghost.visible = isvisible
 	is_building = isvisible
 	if not isvisible:
-		General.is_allowed_to_shoot = true
+	General.is_allowed_to_shoot = true
+	print_debug("Set building state: ", isvisible)
 
 
 # Updates the material of the construction ghost based on the construction type and choice

--- a/Scripts/BuildingMenu.gd
+++ b/Scripts/BuildingMenu.gd
@@ -30,3 +30,10 @@ func _on_construction_option_button_item_selected(index: int) -> void:
 		Helper.signal_broker.construction_chosen.emit("block", "concrete_wall")
 	else:
 		Helper.signal_broker.construction_chosen.emit("furniture", selected_text)
+
+# Returns the currently selected construction type and choice
+func get_selected_type_and_choice() -> Dictionary:
+	var selected_text: String = construction_option_button.get_item_text(construction_option_button.selected)
+	if selected_text == "concrete_wall":
+		return {"type": "block", "choice": "concrete_wall"}
+	return {"type": "furniture", "choice": selected_text}

--- a/Scripts/ConstructionGhost.gd
+++ b/Scripts/ConstructionGhost.gd
@@ -26,6 +26,7 @@ signal construction_clicked(data: Dictionary)
 func _ready():
 	# Connect the signal for construction clicks to the build manager
 	construction_clicked.connect(buildmanager.on_construction_clicked)
+	visibility_changed.connect(_on_visibility_changed)
 
 
 func _process(_delta):
@@ -172,6 +173,8 @@ func set_mesh_rotation(new_rotation: int) -> void:
 	# Update the current rotation
 	current_rotation = new_rotation % 360
 
+	print_debug("ConstructionGhost rotation: ", current_rotation)
+
 	# Update the ghost's rotation
 	rotation_degrees.y = current_rotation
 
@@ -194,7 +197,11 @@ func _on_construction_ghost_area_3d_body_entered(body: Node3D) -> void:
 func _on_construction_ghost_area_3d_body_exited(body: Node3D) -> void:
 	# Check if no other obstacles remain in the area
 	if construction_ghost_area_3d.get_overlapping_bodies().size() == 0:
-		has_obstacle = false
+	has_obstacle = false
+
+# Logs visibility changes
+func _on_visibility_changed() -> void:
+	print_debug("ConstructionGhost visibility: ", visible)
 
 func reset_to_default():
 	reset_rotation_to_default()

--- a/Tests/Unit/test_build_ghost_visibility.gd
+++ b/Tests/Unit/test_build_ghost_visibility.gd
@@ -1,0 +1,44 @@
+extends GutTest
+
+var level_scene: PackedScene
+var level_instance: Node
+var build_manager: BuildManager
+var building_menu: Control
+
+func before_all():
+	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
+	Runtimedata.reconstruct(custom_mods)
+	await get_tree().process_frame
+
+func before_each():
+	level_scene = load("res://level_generation.tscn")
+	level_instance = level_scene.instantiate()
+	add_child(level_instance)
+	await get_tree().process_frame
+	build_manager = level_instance.get_node("TacticalMap/BuildManager")
+	building_menu = level_instance.get_node("HUD/BuildingMenu")
+
+func after_each():
+	if level_instance:
+		level_instance.queue_free()
+	await get_tree().process_frame
+
+func after_all():
+	Runtimedata.reset()
+
+func test_ghost_visible_on_first_menu_open():
+	building_menu.show()
+	await get_tree().process_frame
+	assert_true(build_manager.construction_ghost.visible, "Ghost should be visible when menu opens")
+
+func test_ghost_updates_on_selection_change():
+	building_menu.show()
+	await get_tree().process_frame
+	var option_button: OptionButton = building_menu.get_node(building_menu.construction_option_button)
+	# Ensure at least two options
+	assert_true(option_button.item_count > 1, "Need second option for test")
+	option_button.select(1)
+	building_menu._on_construction_option_button_item_selected(1)
+	await get_tree().process_frame
+	var expected_choice = option_button.get_item_text(1)
+	assert_eq(build_manager.construction_choice, expected_choice, "Ghost choice should update")

--- a/Tests/Unit/test_build_ghost_visibility.gd.uid
+++ b/Tests/Unit/test_build_ghost_visibility.gd.uid
@@ -1,0 +1,1 @@
+uid://dhnscomxasg4c


### PR DESCRIPTION
## Summary
- update task list for progress
- show construction ghost when starting building and when the menu opens
- add helper to query selected build option
- add debug logging to construction scripts
- add unit test covering ghost visibility

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_6873f74193588325b43881b67b9ce5a7