### PR TITLE
Close PRD review: add missing crafting tests

### DIFF
--- a/.project-management/current-prd/tasks-prd-crafting-skill-bonus-stat.md
+++ b/.project-management/current-prd/tasks-prd-crafting-skill-bonus-stat.md
@@ -56,5 +56,6 @@
 - [x] 3.0 Extend `Scripts/Gamedata/DItem.gd` and `Scripts/Runtimedata/RItem.gd` craft structures to store the stat reference.
 - [x] 4.0 Modify `Scripts/crafting_recipes_manager.gd` to include the selected stat in skill requirement checks.
 - [x] 5.0 Add unit tests verifying stat bonus application and default behavior when no stat is set.
+- [x] 6.0 Add missing unit tests verifying skill bonus stat functionality.
 
 *End of document*

--- a/Tests/Unit/test_crafting_bonus_stat.gd
+++ b/Tests/Unit/test_crafting_bonus_stat.gd
@@ -29,13 +29,13 @@ func _create_recipe(level: int, bonus_stat: String = "") -> RItem.CraftRecipe:
 	return RItem.CraftRecipe.new(data)
 
 func test_has_required_skill_without_bonus_stat():
-	player.skills["fabrication"]["level"] = 2
+	player.skills["fabrication"] = {"level": 2, "xp": 0}
 	player.set_stat("strength", 5)
 	var recipe := _create_recipe(5)
 	assert_false(CraftingRecipesManager.has_required_skill(recipe), "Crafting should fail without bonus stat")
 
 func test_has_required_skill_with_bonus_stat():
-	player.skills["fabrication"]["level"] = 2
+	player.skills["fabrication"] = {"level": 2, "xp": 0}
 	player.set_stat("strength", 5)
 	var recipe := _create_recipe(5, "strength")
 	assert_true(CraftingRecipesManager.has_required_skill(recipe), "Crafting should succeed with bonus stat")

--- a/Tests/Unit/test_crafting_bonus_stat.gd
+++ b/Tests/Unit/test_crafting_bonus_stat.gd
@@ -1,0 +1,41 @@
+extends GutTest
+
+var player: Player
+
+func before_all():
+	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
+	Runtimedata.reconstruct(custom_mods)
+	await get_tree().process_frame
+
+func before_each():
+	const PLAYER_SCENE = preload("res://Scenes/player.tscn")
+	player = PLAYER_SCENE.instantiate()
+	player.testing = true
+	add_child(player)
+	await get_tree().process_frame
+
+func after_each():
+	if player:
+		player.queue_free()
+
+func after_all():
+	Runtimedata.reset()
+
+func _create_recipe(level: int, bonus_stat: String = "") -> RItem.CraftRecipe:
+	var data := {
+		"skill_requirement": {"id": "fabrication", "level": level},
+		"skill_bonus_stat": bonus_stat
+	}
+	return RItem.CraftRecipe.new(data)
+
+func test_has_required_skill_without_bonus_stat():
+	player.skills["fabrication"]["level"] = 2
+	player.set_stat("strength", 5)
+	var recipe := _create_recipe(5)
+	assert_false(CraftingRecipesManager.has_required_skill(recipe), "Crafting should fail without bonus stat")
+
+func test_has_required_skill_with_bonus_stat():
+	player.skills["fabrication"]["level"] = 2
+	player.set_stat("strength", 5)
+	var recipe := _create_recipe(5, "strength")
+	assert_true(CraftingRecipesManager.has_required_skill(recipe), "Crafting should succeed with bonus stat")

--- a/Tests/Unit/test_crafting_bonus_stat.gd.uid
+++ b/Tests/Unit/test_crafting_bonus_stat.gd.uid
@@ -1,0 +1,1 @@
+uid://bqobmcp37swc7


### PR DESCRIPTION
## Summary
- add unit test covering the crafting skill bonus stat logic
- note follow-up testing task in `tasks-prd-crafting-skill-bonus-stat.md`

## Testing
- `godot --headless --import` *(fails: Unrecognized UID)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: failed loading resources)*

------
https://chatgpt.com/codex/tasks/task_e_6874043fa270832581261c385d693471