### PR TITLE
Create tasks from PRD

### DIFF
--- a/.project-management/current-prd/tasks-prd-hide-context-menu-options.md
+++ b/.project-management/current-prd/tasks-prd-hide-context-menu-options.md
@@ -1,0 +1,107 @@
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Assets
+│   └── Fonts
+├── Defaults
+│   ├── Blocks
+│   ├── Mobs
+│   ├── Player
+│   ├── Projectiles
+│   ├── Shaders
+│   └── Sprites
+├── Documentation
+│   ├── Game_design
+│   ├── Game_development
+│   └── Modding
+├── FeatureList.md
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── README.md
+├── Scenes
+│   ├── ContentManager
+│   ├── GameOver.tscn
+│   ├── InventoryContainerListItem.tscn
+│   ├── InventoryWindow.tscn
+│   ├── LoadingScreen.tscn
+│   ├── Overmap
+│   ├── UI
+│   ├── input_manager.tscn
+│   └── player.tscn
+├── Scripts
+│   ├── AttributesWindow.gd
+│   ├── AttributesWindow.gd.uid
+│   ├── BuildManager.gd
+│   ├── BuildManager.gd.uid
+│   ├── BuildingMenu.gd
+│   ├── BuildingMenu.gd.uid
+│   ├── Camera.gd
+│   ├── Camera.gd.uid
+│   ├── CharacterWindow.gd
+│   ├── CharacterWindow.gd.uid
+│   ├── Chunk.gd
+│   ├── Chunk.gd.uid
+│   ├── ChunkLevel.gd
+│   ├── ChunkLevel.gd.uid
+│   ├── Client.gd
+│   ├── Client.gd.uid
+│   ├── Components
+│   ├── ConstructionGhost.gd
+│   ├── ConstructionGhost.gd.uid
+│   ├── CraftingMenu.gd
+│   ├── CraftingMenu.gd.uid
+│   ├── CtrlInventoryStackedCustom.gd
+│   ├── CtrlInventoryStackedCustom.gd.uid
+│   ├── CtrlInventoryStackedListItem.gd
+│   ├── CtrlInventoryStackedListItem.gd.uid
+│   ├── CtrlInventoryStackedlistHeaderItem.gd
+│   ├── CtrlInventoryStackedlistHeaderItem.gd.uid
+│   ├── Documentation.gd
+│   ├── Documentation.gd.uid
+│   ├── EquipmentSlot.gd
+│   ├── EquipmentSlot.gd.uid
+│   ├── EquippedItem.gd
+│   ├── EquippedItem.gd.uid
+│   ├── EscapeMenu.gd
+│   ├── EscapeMenu.gd.uid
+```
+## Relevant Files
+- `Scenes/UI/CtrlInventoryStackedCustom.tscn`
+- `Scripts/CtrlInventoryStackedCustom.gd`
+### Proposed New Files
+- `Tests/Unit/test_context_menu_options.gd` - Unit tests for context menu item visibility.
+### Existing Files Modified
+- `Scripts/CtrlInventoryStackedCustom.gd` - Build menu dynamically to hide inapplicable options.
+- `Scenes/UI/CtrlInventoryStackedCustom.tscn` - Ensure node setup supports runtime menu updates.
+
+### Notes
+- Unit tests should typically be placed in /Tests/Unit/.
+- Use the existing logic that currently disables options to determine which menu items are removed.
+- Keep the ordering of menu options consistent so players recognize familiar actions.
+
+## Tasks
+- [ ] 1.0 Refactor context menu building in `CtrlInventoryStackedCustom.gd`
+  - [ ] 1.1 Locate the method that populates the context menu
+  - [ ] 1.2 Use existing enable/disable logic to determine valid actions
+  - [ ] 1.3 Remove menu entries that do not pass the check
+  - [ ] 1.4 Ensure mod-added actions follow the same filtering
+- [ ] 2.0 Update `CtrlInventoryStackedCustom.tscn` if needed for dynamic menu
+  - [ ] 2.1 Review node structure for menu buttons
+  - [ ] 2.2 Add or adjust containers to support runtime menu updates
+- [ ] 3.0 Verify mod signals remain functional with hidden options
+  - [ ] 3.1 Test base game context menu actions after refactor
+  - [ ] 3.2 Run a sample mod to confirm its actions still emit signals
+- [ ] 4.0 Add unit tests verifying valid options appear for various items
+  - [ ] 4.1 Create `Tests/Unit/test_context_menu_options.gd`
+  - [ ] 4.2 Test that universal actions like `Drop` always appear
+  - [ ] 4.3 Test that inapplicable actions are omitted
+- [ ] 5.0 Update user documentation to describe the simplified menu
+  - [ ] 5.1 Document new behavior in `Documentation/Game_development/` guides
+  - [ ] 5.2 Note how mods should supply context menu actions
+*End of document*


### PR DESCRIPTION
## Summary
- generate high-level tasks for PRD: hide unavailable context menu options
- add sub-tasks for context menu cleanup and tests

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_6876ab3047b483259575331a2bdbb752