### PR TITLE
Replace magazine list with Editable_Item_List

### DIFF
--- a/.project-management/current-prd/tasks-prd-improved-magazine-editor.md
+++ b/.project-management/current-prd/tasks-prd-improved-magazine-editor.md
@@ -26,10 +26,10 @@
 - Field should be collapsible if space is limited.
 
 ## Tasks
-- [ ] 1.0 Replace magazine selection UI in `ItemRangedEditor.tscn` with `Editable_Item_List` to allow drag-and-drop magazines.
-  - [ ] 1.1 Locate current magazine list node and remove it.
-  - [ ] 1.2 Instance `Editable_Item_List` and position it in the editor UI.
-  - [ ] 1.3 Expose the new widget as a script variable for later access.
+- [c] 1.0 Replace magazine selection UI in `ItemRangedEditor.tscn` with `Editable_Item_List` to allow drag-and-drop magazines.
+  - [c] 1.1 Locate current magazine list node and remove it.
+  - [c] 1.2 Instance `Editable_Item_List` and position it in the editor UI.
+  - [c] 1.3 Expose the new widget as a script variable for later access.
 - [ ] 2.0 Implement drop validation in `ItemRangedEditor.gd` to only accept items of type `magazine` using logic from `Editable_Item_List`.
   - [ ] 2.1 Connect the drop signal from the `Editable_Item_List` widget.
   - [ ] 2.2 Verify the dropped item type using `DropEntityTextEdit` logic.

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
@@ -2,8 +2,9 @@
 
 [ext_resource type="Script" uid="uid://cibcfcysyj15" path="res://Scripts/ItemRangedEditor.gd" id="1_my1v7"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_crphu"]
+[ext_resource type="PackedScene" uid="uid://b8i6wfk3fngy4" path="res://Scenes/ContentManager/Custom_Widgets/Editable_Item_List.tscn" id="3_mag"]
 
-[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "accuracy_stat_text_edit")]
+[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "MagazinesEditable_Item_List", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "accuracy_stat_text_edit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -12,7 +13,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_my1v7")
 UsedAmmoTextEdit = NodePath("Ranged/UsedAmmoTextEdit")
-UsedMagazineContainer = NodePath("Ranged/ScrollContainer/UsedMagazineContainer")
+MagazinesEditable_Item_List = NodePath("Ranged/MagazinesEditable_Item_List")
 RangeNumberBox = NodePath("Ranged/RangeNumber")
 SpreadNumberBox = NodePath("Ranged/SpreadNumber")
 SwayNumberBox = NodePath("Ranged/SwayNumber")
@@ -42,24 +43,18 @@ custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
-focus_next = NodePath("../ScrollContainer/UsedMagazineContainer")
+focus_next = NodePath("../MagazinesEditable_Item_List")
 placeholder_text = "9mm"
 
 [node name="UsedMagazineLabel" type="Label" parent="Ranged"]
 layout_mode = 2
 text = "Magazine"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Ranged"]
+[node name="MagazinesEditable_Item_List" parent="Ranged" instance=ExtResource("3_mag")]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-
-[node name="UsedMagazineContainer" type="VBoxContainer" parent="Ranged/ScrollContainer"]
-custom_minimum_size = Vector2(0, 28)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.9
-focus_previous = NodePath("../../UsedAmmoTextEdit")
+header = "Magazines"
 
 [node name="RangeLabel" type="Label" parent="Ranged"]
 layout_mode = 2

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -5,7 +5,7 @@ extends Control
 
 # Ranged form elements
 @export var UsedAmmoTextEdit: TextEdit = null
-@export var UsedMagazineContainer: VBoxContainer = null  # This will hold the magazine selection CheckButtons
+@export var MagazinesEditable_Item_List: Control = null  # Drag-and-drop magazine list widget
 @export var RangeNumberBox: SpinBox = null
 @export var SpreadNumberBox: SpinBox = null
 @export var SwayNumberBox: SpinBox = null
@@ -25,29 +25,14 @@ var ditem: DItem = null:
 
 
 func _ready():
-	set_drop_functions()
-	# Assume Gamedata.get_items_by_type() is implemented as discussed previously
-	var all_mods: Dictionary = Gamedata.mods.get_all()
-	var magazines: Array = []
-	for mod: DMod in all_mods.values(): # Add up all magazines from all mods
-		magazines = Helper.json_helper.merge_unique(mod.items.get_items_by_type("magazine"), magazines)
-	initialize_magazine_selection(magazines)
+        set_drop_functions()
 
 
-func initialize_magazine_selection(magazines: Array):
-	for magazine in magazines:
-		var magazine_button = CheckBox.new()
-		magazine_button.text = magazine["id"]
-		magazine_button.toggle_mode = true
-		UsedMagazineContainer.add_child(magazine_button)
 
 
 # Returns the properties of the ranged tab in the item editor
 func save_properties() -> void:
-	var selected_magazines = []
-	for button in UsedMagazineContainer.get_children():
-		if button is CheckBox and button.button_pressed:
-			selected_magazines.append(button.text)
+        var selected_magazines: Array = MagazinesEditable_Item_List.get_items()
 	
 	ditem.ranged.used_ammo = UsedAmmoTextEdit.text
 	ditem.ranged.used_magazine = ",".join(selected_magazines)  # Join the selected magazines by commas
@@ -75,11 +60,11 @@ func load_properties() -> void:
 		return
 	if ditem.ranged.used_ammo != "":
 		UsedAmmoTextEdit.text = ditem.ranged.used_ammo
-	if ditem.ranged.used_magazine != "":
-		var used_magazines = ditem.ranged.used_magazine.split(",")
-		for button in UsedMagazineContainer.get_children():
-			if button is CheckBox:
-				button.button_pressed = button.text in used_magazines
+        if ditem.ranged.used_magazine != "":
+                var used_magazines = ditem.ranged.used_magazine.split(",")
+                MagazinesEditable_Item_List.set_items(used_magazines)
+        else:
+                MagazinesEditable_Item_List.clear_list()
 	RangeNumberBox.value = ditem.ranged.firing_range
 	SpreadNumberBox.value = ditem.ranged.spread
 	SwayNumberBox.value = ditem.ranged.sway


### PR DESCRIPTION
## Summary
- commit to magazine editor tasks
- swap magazine list nodes for `Editable_Item_List`
- expose new list widget to script
- update save/load logic for new widget

## Testing
- `godot --headless --path "$PWD" --import` *(fails: Unrecognized UID)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: resource import errors)*

------
https://chatgpt.com/codex/tasks/task_e_687798f82fbc8325977e4d583b0f0887