### PR TITLE
Add sub-tasks for improved magazine editor

### DIFF
--- a/.project-management/current-prd/tasks-prd-improved-magazine-editor.md
+++ b/.project-management/current-prd/tasks-prd-improved-magazine-editor.md
@@ -1,0 +1,205 @@
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Assets
+│   └── Fonts
+├── Defaults
+│   ├── Blocks
+│   ├── Mobs
+│   ├── Player
+│   ├── Projectiles
+│   ├── Shaders
+│   └── Sprites
+├── Documentation
+│   ├── Game_design
+│   ├── Game_development
+│   └── Modding
+├── FeatureList.md
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── README.md
+├── Scenes
+│   ├── ContentManager
+│   ├── GameOver.tscn
+│   ├── InventoryContainerListItem.tscn
+│   ├── InventoryWindow.tscn
+│   ├── LoadingScreen.tscn
+│   ├── Overmap
+│   ├── UI
+│   ├── input_manager.tscn
+│   └── player.tscn
+├── Scripts
+│   ├── AttributesWindow.gd
+│   ├── AttributesWindow.gd.uid
+│   ├── BuildManager.gd
+│   ├── BuildManager.gd.uid
+│   ├── BuildingMenu.gd
+│   ├── BuildingMenu.gd.uid
+│   ├── Camera.gd
+│   ├── Camera.gd.uid
+│   ├── CharacterWindow.gd
+│   ├── CharacterWindow.gd.uid
+│   ├── Chunk.gd
+│   ├── Chunk.gd.uid
+│   ├── ChunkLevel.gd
+│   ├── ChunkLevel.gd.uid
+│   ├── Client.gd
+│   ├── Client.gd.uid
+│   ├── Components
+│   ├── ConstructionGhost.gd
+│   ├── ConstructionGhost.gd.uid
+│   ├── CraftingMenu.gd
+│   ├── CraftingMenu.gd.uid
+│   ├── CtrlInventoryStackedCustom.gd
+│   ├── CtrlInventoryStackedCustom.gd.uid
+│   ├── CtrlInventoryStackedListItem.gd
+│   ├── CtrlInventoryStackedListItem.gd.uid
+│   ├── CtrlInventoryStackedlistHeaderItem.gd
+│   ├── CtrlInventoryStackedlistHeaderItem.gd.uid
+│   ├── Documentation.gd
+│   ├── Documentation.gd.uid
+│   ├── EquipmentSlot.gd
+│   ├── EquipmentSlot.gd.uid
+│   ├── EquippedItem.gd
+│   ├── EquippedItem.gd.uid
+│   ├── EscapeMenu.gd
+│   ├── EscapeMenu.gd.uid
+│   ├── FurnitureBlueprintSpawner.gd
+│   ├── FurnitureBlueprintSpawner.gd.uid
+│   ├── FurnitureBlueprintSrv.gd
+│   ├── FurnitureBlueprintSrv.gd.uid
+│   ├── FurnitureConstructionWindow.gd
+│   ├── FurnitureConstructionWindow.gd.uid
+│   ├── FurniturePhysicsSpawner.gd
+│   ├── FurniturePhysicsSpawner.gd.uid
+│   ├── FurniturePhysicsSrv.gd
+│   ├── FurniturePhysicsSrv.gd.uid
+│   ├── FurniturePhysicsSrv.gd.uid
+│   ├── FurnitureStaticSpawner.gd
+│   ├── FurnitureStaticSpawner.gd.uid
+│   ├── FurnitureStaticSrv.gd
+│   ├── FurnitureStaticSrv.gd.uid
+│   ├── FurnitureWindow.gd
+│   ├── FurnitureWindow.gd.uid
+│   ├── GameOver.gd
+│   ├── GameOver.gd.uid
+│   ├── Gamedata
+│   ├── HeldItem.gd
+│   ├── HeldItem.gd.uid
+│   ├── Helper
+│   ├── Helper.gd
+│   ├── Helper.gd.uid
+│   ├── InventoryContainerListItem.gd
+│   ├── InventoryContainerListItem.gd.uid
+│   ├── InventoryWindow.gd
+│   ├── InventoryWindow.gd.uid
+│   ├── ItemAmmoEditor.gd
+│   ├── ItemAmmoEditor.gd.uid
+│   ├── ItemCraftEditor.gd
+│   ├── ItemCraftEditor.gd.uid
+│   ├── ItemDetector.gd
+│   ├── ItemDetector.gd.uid
+│   ├── ItemEditor.gd
+│   ├── ItemEditor.gd.uid
+│   ├── ItemFoodEditor.gd
+│   ├── ItemFoodEditor.gd.uid
+│   ├── ItemMagazineEditor.gd
+│   ├── ItemMagazineEditor.gd.uid
+│   ├── ItemMedicalEditor.gd
+│   ├── ItemMedicalEditor.gd.uid
+│   ├── ItemMeleeEditor.gd
+│   ├── ItemMeleeEditor.gd.uid
+│   ├── ItemRangedEditor.gd
+│   ├── ItemRangedEditor.gd.uid
+│   ├── ItemToolEditor.gd
+│   ├── ItemToolEditor.gd.uid
+│   ├── ItemWearableEditor.gd
+│   ├── ItemWearableEditor.gd.uid
+│   ├── LoadingScreen.gd
+│   ├── LoadingScreen.gd.uid
+│   ├── Mob
+│   ├── NonHUDclick.gd
+│   ├── NonHUDclick.gd.uid
+│   ├── OvermapGrid.gd
+│   ├── OvermapGrid.gd.uid
+│   ├── PlayerAttribute.gd
+│   ├── PlayerAttribute.gd.uid
+│   ├── PlayerShooting.gd
+│   ├── PlayerShooting.gd.uid
+│   ├── QuestTrackerUI.gd
+│   ├── QuestTrackerUI.gd.uid
+│   ├── QuestWindow.gd
+│   ├── QuestWindow.gd.uid
+│   ├── Runtimedata
+│   ├── WearableSlot.gd
+│   ├── WearableSlot.gd.uid
+│   ├── bullet.gd
+│   ├── bullet.gd.uid
+│   ├── container.gd
+│   ├── container.gd.uid
+│   ├── crafting_recipes_manager.gd
+│   ├── crafting_recipes_manager.gd.uid
+│   ├── gamedata.gd
+│   ├── gamedata.gd.uid
+│   ├── general.gd
+│   ├── general.gd.uid
+│   ├── hud.gd
+│   ├── hud.gd.uid
+│   ├── input_manager.gd
+│   ├── input_manager.gd.uid
+│   ├── item_manager.gd
+│   ├── item_manager.gd.uid
+│   ├── player.gd
+│   ├── player.gd.uid
+│   ├── runtimedata.gd
+│   ├── runtimedata.gd.uid
+│   ├── scene_selector.gd
+│   ├── scene_selector.gd.uid
+```
+
+## Relevant Files
+- `Scripts/ItemRangedEditor.gd` - Handles ranged item editing logic including magazine selection.
+- `Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn` - UI for editing ranged items.
+- `Scenes/ContentManager/Custom_Editors/mobfactions_editor.gd` - Reference implementation showing grid container list management.
+- `/Tests/Unit` - Contains unit tests for editor scripts.
+
+### Proposed New Files
+*(none yet)*
+
+### Existing Files Modified
+- `Scripts/ItemRangedEditor.gd`
+- `Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn`
+- Possibly new test file under `/Tests/Unit`.
+
+### Notes
+- Follow Godot 4.4 best practices and use GDScript 4 syntax.
+- Drag-and-drop behavior should validate item type `magazine`.
+- Store magazine IDs as comma-separated string for compatibility with existing JSON.
+
+
+## Tasks
+- [ ] 1.0 Replace magazine list UI with a grid container similar to mobfactions_editor.
+  - [ ] 1.1 Replace existing list with a `GridContainer` inspired by `hostile_grid_container` in `mobfactions_editor.gd`.
+  - [ ] 1.2 Connect the container to `ItemRangedEditor.gd` using drag forwarding.
+  - [ ] 1.3 Remove the old scroll container node.
+- [ ] 2.0 Validate dropped items to ensure they are magazines.
+  - [ ] 2.1 Implement drop callback to check item type.
+  - [ ] 2.2 Show warning or ignore drops that are not magazines.
+- [ ] 3.0 Update save/load logic for comma-separated magazine IDs.
+  - [ ] 3.1 Convert list entries to comma-separated string on save.
+  - [ ] 3.2 Parse stored string into list when loading existing items.
+- [ ] 4.0 Provide ability to remove magazines from list via UI.
+  - [ ] 4.1 Provide delete buttons for each magazine entry similar to mobfactions_editor.
+  - [ ] 4.2 Update underlying data when entries are removed.
+- [ ] 5.0 Add unit tests for magazine drag-and-drop and serialization.
+  - [ ] 5.1 Test valid magazine drop adds ID to list.
+  - [ ] 5.2 Test invalid drop is ignored.
+  - [ ] 5.3 Test save and load preserve magazine IDs.
+
+*End of document*


### PR DESCRIPTION
## Summary
- flesh out tasks for improved magazine editor
- revise tasks to mimic faction editor grid behavior

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_68779fc4851c83258b9203e04cf8201b