### PR TITLE
Implement grid-based magazine editor

### DIFF
--- a/.project-management/current-prd/tasks-prd-improved-magazine-editor.md
+++ b/.project-management/current-prd/tasks-prd-improved-magazine-editor.md
@@ -170,12 +170,12 @@
 - `/Tests/Unit` - Contains unit tests for editor scripts.
 
 ### Proposed New Files
-*(none yet)*
+- `Tests/Unit/test_item_ranged_editor.gd` - Unit tests for magazine editor drag and drop and serialization.
 
 ### Existing Files Modified
 - `Scripts/ItemRangedEditor.gd`
 - `Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn`
-- Possibly new test file under `/Tests/Unit`.
+- `Tests/Unit/test_item_ranged_editor.gd`
 
 ### Notes
 - Follow Godot 4.4 best practices and use GDScript 4 syntax.
@@ -184,22 +184,22 @@
 
 
 ## Tasks
-- [ ] 1.0 Replace magazine list UI with a grid container similar to mobfactions_editor.
-  - [ ] 1.1 Replace existing list with a `GridContainer` inspired by `hostile_grid_container` in `mobfactions_editor.gd`.
-  - [ ] 1.2 Connect the container to `ItemRangedEditor.gd` using drag forwarding.
-  - [ ] 1.3 Remove the old scroll container node.
-- [ ] 2.0 Validate dropped items to ensure they are magazines.
-  - [ ] 2.1 Implement drop callback to check item type.
-  - [ ] 2.2 Show warning or ignore drops that are not magazines.
-- [ ] 3.0 Update save/load logic for comma-separated magazine IDs.
-  - [ ] 3.1 Convert list entries to comma-separated string on save.
-  - [ ] 3.2 Parse stored string into list when loading existing items.
-- [ ] 4.0 Provide ability to remove magazines from list via UI.
-  - [ ] 4.1 Provide delete buttons for each magazine entry similar to mobfactions_editor.
-  - [ ] 4.2 Update underlying data when entries are removed.
-- [ ] 5.0 Add unit tests for magazine drag-and-drop and serialization.
-  - [ ] 5.1 Test valid magazine drop adds ID to list.
-  - [ ] 5.2 Test invalid drop is ignored.
-  - [ ] 5.3 Test save and load preserve magazine IDs.
+- [c] 1.0 Replace magazine list UI with a grid container similar to mobfactions_editor.
+  - [c] 1.1 Replace existing list with a `GridContainer` inspired by `hostile_grid_container` in `mobfactions_editor.gd`.
+  - [c] 1.2 Connect the container to `ItemRangedEditor.gd` using drag forwarding.
+  - [c] 1.3 Remove the old scroll container node.
+- [c] 2.0 Validate dropped items to ensure they are magazines.
+  - [c] 2.1 Implement drop callback to check item type.
+  - [c] 2.2 Show warning or ignore drops that are not magazines.
+- [c] 3.0 Update save/load logic for comma-separated magazine IDs.
+  - [c] 3.1 Convert list entries to comma-separated string on save.
+  - [c] 3.2 Parse stored string into list when loading existing items.
+- [c] 4.0 Provide ability to remove magazines from list via UI.
+  - [c] 4.1 Provide delete buttons for each magazine entry similar to mobfactions_editor.
+  - [c] 4.2 Update underlying data when entries are removed.
+- [c] 5.0 Add unit tests for magazine drag-and-drop and serialization.
+  - [c] 5.1 Test valid magazine drop adds ID to list.
+  - [c] 5.2 Test invalid drop is ignored.
+  - [c] 5.3 Test save and load preserve magazine IDs.
 
 *End of document*

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://cibcfcysyj15" path="res://Scripts/ItemRangedEditor.gd" id="1_my1v7"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_crphu"]
 
-[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "accuracy_stat_text_edit")]
+[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineGridContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "accuracy_stat_text_edit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -12,7 +12,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_my1v7")
 UsedAmmoTextEdit = NodePath("Ranged/UsedAmmoTextEdit")
-UsedMagazineContainer = NodePath("Ranged/ScrollContainer/UsedMagazineContainer")
+UsedMagazineGridContainer = NodePath("Ranged/UsedMagazineGridContainer")
 RangeNumberBox = NodePath("Ranged/RangeNumber")
 SpreadNumberBox = NodePath("Ranged/SpreadNumber")
 SwayNumberBox = NodePath("Ranged/SwayNumber")
@@ -42,24 +42,20 @@ custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.1
-focus_next = NodePath("../ScrollContainer/UsedMagazineContainer")
+focus_next = NodePath("../UsedMagazineGridContainer")
 placeholder_text = "9mm"
 
 [node name="UsedMagazineLabel" type="Label" parent="Ranged"]
 layout_mode = 2
 text = "Magazine"
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Ranged"]
+[node name="UsedMagazineGridContainer" type="GridContainer" parent="Ranged"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-
-[node name="UsedMagazineContainer" type="VBoxContainer" parent="Ranged/ScrollContainer"]
+columns = 3
 custom_minimum_size = Vector2(0, 28)
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.9
-focus_previous = NodePath("../../UsedAmmoTextEdit")
+focus_previous = NodePath("../UsedAmmoTextEdit")
 
 [node name="RangeLabel" type="Label" parent="Ranged"]
 layout_mode = 2

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -25,38 +25,38 @@ var ditem: DItem = null:
 
 
 func _ready():
-       set_drop_functions()
-       if UsedMagazineGridContainer:
-               UsedMagazineGridContainer.set_drag_forwarding(Callable(), _can_magazine_drop, _magazine_drop)
+	set_drop_functions()
+	if UsedMagazineGridContainer:
+		UsedMagazineGridContainer.set_drag_forwarding(Callable(), _can_magazine_drop, _magazine_drop)
 
 
 func _add_magazine_entry(magazine_id: String) -> void:
-       var item_sprite: Texture = Gamedata.mods.get_content_by_id(DMod.ContentType.ITEMS, magazine_id).sprite
-       var icon = TextureRect.new()
-       icon.texture = item_sprite
-       icon.custom_minimum_size = Vector2(32, 32)
+	var item_sprite: Texture = Gamedata.mods.get_content_by_id(DMod.ContentType.ITEMS, magazine_id).sprite
+	var icon = TextureRect.new()
+	icon.texture = item_sprite
+	icon.custom_minimum_size = Vector2(32, 32)
 
-       var label = Label.new()
-       label.text = magazine_id
+	var label = Label.new()
+	label.text = magazine_id
 
-       var delete_button = Button.new()
-       delete_button.text = "X"
-       delete_button.button_up.connect(_on_delete_magazine_button_pressed.bind([icon, label, delete_button]))
+	var delete_button = Button.new()
+	delete_button.text = "X"
+	delete_button.button_up.connect(_on_delete_magazine_button_pressed.bind([icon, label, delete_button]))
 
-       UsedMagazineGridContainer.add_child(icon)
-       UsedMagazineGridContainer.add_child(label)
-       UsedMagazineGridContainer.add_child(delete_button)
+	UsedMagazineGridContainer.add_child(icon)
+	UsedMagazineGridContainer.add_child(label)
+	UsedMagazineGridContainer.add_child(delete_button)
 
 
 # Returns the properties of the ranged tab in the item editor
 func save_properties() -> void:
-       var selected_magazines: Array[String] = []
-       var num_columns: int = UsedMagazineGridContainer.columns
-       var children := UsedMagazineGridContainer.get_children()
-       for i in range(0, children.size(), num_columns):
-               var label := children[i + 1] as Label
-               if label:
-                       selected_magazines.append(label.text)
+	var selected_magazines: Array[String] = []
+	var num_columns: int = UsedMagazineGridContainer.columns
+	var children := UsedMagazineGridContainer.get_children()
+	for i in range(0, children.size(), num_columns):
+		var label := children[i + 1] as Label
+		if label:
+			selected_magazines.append(label.text)
 	
 	ditem.ranged.used_ammo = UsedAmmoTextEdit.text
 	ditem.ranged.used_magazine = ",".join(selected_magazines)  # Join the selected magazines by commas
@@ -84,12 +84,12 @@ func load_properties() -> void:
 		return
 	if ditem.ranged.used_ammo != "":
 		UsedAmmoTextEdit.text = ditem.ranged.used_ammo
-       if UsedMagazineGridContainer:
-               Helper.free_all_children(UsedMagazineGridContainer)
-       if ditem.ranged.used_magazine != "":
-               var used_magazines = ditem.ranged.used_magazine.split(",")
-               for mag_id in used_magazines:
-                       _add_magazine_entry(mag_id)
+		if UsedMagazineGridContainer:
+			Helper.free_all_children(UsedMagazineGridContainer)
+		if ditem.ranged.used_magazine != "":
+			var used_magazines = ditem.ranged.used_magazine.split(",")
+			for mag_id in used_magazines:
+				_add_magazine_entry(mag_id)
 	RangeNumberBox.value = ditem.ranged.firing_range
 	SpreadNumberBox.value = ditem.ranged.spread
 	SwayNumberBox.value = ditem.ranged.sway
@@ -141,38 +141,37 @@ func stat_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void
 		print_debug("Dropped data does not contain an 'id' key.")
 
 func can_stat_drop(dropped_data: Dictionary):
-       if not dropped_data or not dropped_data.has("id"):
-               return false
-       return Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(dropped_data["id"])
+	if not dropped_data or not dropped_data.has("id"):
+		return false
+	return Gamedata.mods.by_id(dropped_data["mod_id"]).stats.has_id(dropped_data["id"])
 
 
 # -------------------- Magazine Drag and Drop --------------------
 func _can_magazine_drop(_newpos: Vector2, data: Dictionary) -> bool:
-       if not data or not data.has("id") or not data.has("mod_id"):
-               return false
+	if not data or not data.has("id") or not data.has("mod_id"):
+		return false
 
-       if not Gamedata.mods.by_id(data["mod_id"]).items.has_id(data["id"]):
-               return false
-       var ditem: DItem = Gamedata.mods.by_id(data["mod_id"]).items.by_id(data["id"])
-       if ditem.magazine == null:
-               return false
+	if not Gamedata.mods.by_id(data["mod_id"]).items.has_id(data["id"]):
+		return false
+	var ditem: DItem = Gamedata.mods.by_id(data["mod_id"]).items.by_id(data["id"])
+	if ditem.magazine == null:
+		return false
 
-       for child in UsedMagazineGridContainer.get_children():
-               if child is Label and child.text == data["id"]:
-                       return false
-
-       return true
+	for child in UsedMagazineGridContainer.get_children():
+		if child is Label and child.text == data["id"]:
+			return false
+	return true
 
 
 func _magazine_drop(_newpos: Vector2, data: Dictionary) -> void:
-       if not _can_magazine_drop(_newpos, data):
-               return
-       _add_magazine_entry(data["id"])
+	if not _can_magazine_drop(_newpos, data):
+		return
+	_add_magazine_entry(data["id"])
 
 
 func _on_delete_magazine_button_pressed(controls: Array) -> void:
-       for c in controls:
-               c.queue_free()
+	for c in controls:
+		c.queue_free()
 
 
 # Set the drop functions on the required skill and skill progression controls

--- a/Tests/Unit/test_item_ranged_editor.gd
+++ b/Tests/Unit/test_item_ranged_editor.gd
@@ -1,0 +1,82 @@
+extends GutTest
+
+var ranged_editor_scene: PackedScene = preload("res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn")
+var editor_instance: Control = null
+var my_ditem: DItem = null
+
+func before_all():
+	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
+	Runtimedata.reconstruct(custom_mods)
+	await get_tree().process_frame
+
+func before_each():
+	my_ditem = DItem.new({
+	    "id": "test_ranged_item",
+	    "Ranged": {
+	        "firing_speed": 0.5,
+	        "range": 500,
+	        "recoil": 5,
+	        "reload_speed": 1.0,
+	        "spread": 2,
+	        "sway": 1,
+	        "used_ammo": "9mm",
+	        "used_magazine": ""
+	    }
+	}, null)
+	editor_instance = ranged_editor_scene.instantiate()
+	get_tree().root.add_child(editor_instance)
+	await get_tree().process_frame
+	editor_instance.ditem = my_ditem
+
+func after_each():
+	if editor_instance:
+	    editor_instance.queue_free()
+
+func after_all():
+	Runtimedata.reset()
+
+func test_valid_magazine_drop() -> void:
+	var data := {
+	    "id": "generic_test_pistol_magazine",
+	    "text": "generic_test_pistol_magazine",
+	    "mod_id": "Test",
+	    "contentType": DMod.ContentType.ITEMS
+	}
+	editor_instance._magazine_drop(Vector2.ZERO, data)
+	var found := false
+	for child in editor_instance.UsedMagazineGridContainer.get_children():
+	    if child is Label and child.text == "generic_test_pistol_magazine":
+	        found = true
+	assert_true(found)
+
+func test_invalid_magazine_drop() -> void:
+	var data := {
+	    "id": "generic_test_item",
+	    "text": "generic_test_item",
+	    "mod_id": "Test",
+	    "contentType": DMod.ContentType.ITEMS
+	}
+	editor_instance._magazine_drop(Vector2.ZERO, data)
+	var found := false
+	for child in editor_instance.UsedMagazineGridContainer.get_children():
+	    if child is Label and child.text == "generic_test_item":
+	        found = true
+	assert_false(found)
+
+func test_save_and_load_preserves_magazines() -> void:
+	var data := {
+	    "id": "generic_test_pistol_magazine",
+	    "text": "generic_test_pistol_magazine",
+	    "mod_id": "Test",
+	    "contentType": DMod.ContentType.ITEMS
+	}
+	editor_instance._magazine_drop(Vector2.ZERO, data)
+	editor_instance.save_properties()
+	assert_eq(my_ditem.ranged.used_magazine, "generic_test_pistol_magazine")
+	Helper.free_all_children(editor_instance.UsedMagazineGridContainer)
+	editor_instance.load_properties()
+	var found := false
+	for child in editor_instance.UsedMagazineGridContainer.get_children():
+	    if child is Label and child.text == "generic_test_pistol_magazine":
+	        found = true
+	assert_true(found)

--- a/Tests/Unit/test_item_ranged_editor.gd
+++ b/Tests/Unit/test_item_ranged_editor.gd
@@ -11,17 +11,17 @@ func before_all():
 
 func before_each():
 	my_ditem = DItem.new({
-	    "id": "test_ranged_item",
-	    "Ranged": {
-	        "firing_speed": 0.5,
-	        "range": 500,
-	        "recoil": 5,
-	        "reload_speed": 1.0,
-	        "spread": 2,
-	        "sway": 1,
-	        "used_ammo": "9mm",
-	        "used_magazine": ""
-	    }
+		"id": "test_ranged_item",
+		"Ranged": {
+			"firing_speed": 0.5,
+			"range": 500,
+			"recoil": 5,
+			"reload_speed": 1.0,
+			"spread": 2,
+			"sway": 1,
+			"used_ammo": "9mm",
+			"used_magazine": ""
+		}
 	}, null)
 	editor_instance = ranged_editor_scene.instantiate()
 	get_tree().root.add_child(editor_instance)
@@ -30,45 +30,45 @@ func before_each():
 
 func after_each():
 	if editor_instance:
-	    editor_instance.queue_free()
+		editor_instance.queue_free()
 
 func after_all():
 	Runtimedata.reset()
 
 func test_valid_magazine_drop() -> void:
 	var data := {
-	    "id": "generic_test_pistol_magazine",
-	    "text": "generic_test_pistol_magazine",
-	    "mod_id": "Test",
-	    "contentType": DMod.ContentType.ITEMS
+		"id": "generic_test_pistol_magazine",
+		"text": "generic_test_pistol_magazine",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.ITEMS
 	}
 	editor_instance._magazine_drop(Vector2.ZERO, data)
 	var found := false
 	for child in editor_instance.UsedMagazineGridContainer.get_children():
-	    if child is Label and child.text == "generic_test_pistol_magazine":
-	        found = true
+		if child is Label and child.text == "generic_test_pistol_magazine":
+			found = true
 	assert_true(found)
 
 func test_invalid_magazine_drop() -> void:
 	var data := {
-	    "id": "generic_test_item",
-	    "text": "generic_test_item",
-	    "mod_id": "Test",
-	    "contentType": DMod.ContentType.ITEMS
+		"id": "generic_test_item",
+		"text": "generic_test_item",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.ITEMS
 	}
 	editor_instance._magazine_drop(Vector2.ZERO, data)
 	var found := false
 	for child in editor_instance.UsedMagazineGridContainer.get_children():
-	    if child is Label and child.text == "generic_test_item":
-	        found = true
+		if child is Label and child.text == "generic_test_item":
+			found = true
 	assert_false(found)
 
 func test_save_and_load_preserves_magazines() -> void:
 	var data := {
-	    "id": "generic_test_pistol_magazine",
-	    "text": "generic_test_pistol_magazine",
-	    "mod_id": "Test",
-	    "contentType": DMod.ContentType.ITEMS
+		"id": "generic_test_pistol_magazine",
+		"text": "generic_test_pistol_magazine",
+		"mod_id": "Test",
+		"contentType": DMod.ContentType.ITEMS
 	}
 	editor_instance._magazine_drop(Vector2.ZERO, data)
 	editor_instance.save_properties()
@@ -77,6 +77,6 @@ func test_save_and_load_preserves_magazines() -> void:
 	editor_instance.load_properties()
 	var found := false
 	for child in editor_instance.UsedMagazineGridContainer.get_children():
-	    if child is Label and child.text == "generic_test_pistol_magazine":
-	        found = true
+		if child is Label and child.text == "generic_test_pistol_magazine":
+			found = true
 	assert_true(found)

--- a/Tests/Unit/test_item_ranged_editor.gd.uid
+++ b/Tests/Unit/test_item_ranged_editor.gd.uid
@@ -1,0 +1,1 @@
+uid://dkcefi30pluh


### PR DESCRIPTION
## Summary
- swap magazine list for a GridContainer in ItemRangedEditor scene
- manage magazine entries via drag-and-drop
- save/load comma-separated magazine ID strings
- add unit test covering drag-and-drop and serialization
- update task list

## Testing
- `godot --headless --import` *(fails: Unrecognized UID)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: multiple parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877a81db6388325bf194bdcb98f7499