### PR TITLE
Use typed arrays for chunk queues

### DIFF
--- a/.project-management/current-prd/tasks-refactor-readability.md
+++ b/.project-management/current-prd/tasks-refactor-readability.md
@@ -10,6 +10,7 @@ $(tree -L 1 -I '.git|addons|.*')
 
 ### Existing Files Modified
 - `LevelGenerator.gd` – Simplify chunk queue management.
+- `.project-management/current-prd/tasks-refactor-readability.md` – Update task statuses.
 
 ### Files To Remove
 - *(none)*
@@ -18,5 +19,7 @@ $(tree -L 1 -I '.git|addons|.*')
 - Unit tests should be placed under `/Tests/Unit/`.
 
 ## Tasks
-- [ ] **3.0 Simplify `LevelGenerator.gd` queue management**
-  - [ ] 3.2 Use typed arrays for `load_queue` and `unload_queue`.
+- [x] **3.0 Simplify `LevelGenerator.gd` queue management**
+  - [x] 3.2 Use typed arrays for `load_queue` and `unload_queue`.
+
+*End of document*

--- a/LevelGenerator.gd
+++ b/LevelGenerator.gd
@@ -17,8 +17,8 @@ var loaded_chunks = {} # Dictionary to store loaded chunks with their positions 
 var player_position = Vector2.ZERO # Player's position, updated regularly
 # Chunks are loaded and unloaded one at a time. The load_queue will be processed before the unload_queue
 # Chunks that should be loaded and unloaded are stored inside these variables
-var load_queue = []
-var unload_queue = []
+var load_queue: Array[Vector2] = []
+var unload_queue: Array[Vector2] = []
 # Enforces loading or unloading one chunk at a time
 var is_processing_chunk = false
 const TIME_DELAY: float = 0.4


### PR DESCRIPTION
## Summary
- use typed arrays for `load_queue` and `unload_queue`
- update task list

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_6877d94be23483258865a23630121d4d