### PR TITLE
Implement DNpc persistence

### DIFF
--- a/.project-management/current-prd/tasks-prd-npc-editor.md
+++ b/.project-management/current-prd/tasks-prd-npc-editor.md
@@ -353,8 +353,8 @@
   - [ ] **2.2** Implement `NpcEditor.gd` to load DNpc fields and emit `data_changed` on save.
   - [ ] **2.3** Connect Load and Save buttons to DNpc properties.
 - [ ] **3.0** Implement persistence in DNpc classes
-  - [ ] **3.1** Add `save_to_disk`, `changed`, and `delete` methods in `DNpc.gd`.
-  - [ ] **3.2** Extend `DNpcs.gd` with `save_npcs_to_disk`, `add_new`, `append_new`, and `delete_by_id`.
+  - [c] **3.1** Add `save_to_disk`, `changed`, and `delete` methods in `DNpc.gd`.
+  - [c] **3.2** Extend `DNpcs.gd` with `save_npcs_to_disk`, `add_new`, `append_new`, and `delete_by_id`.
 - [ ] **4.0** Update content editor workflow for NPCs
   - [ ] **4.1** Add packed scene reference to `contenteditor.tscn` for `NpcEditor`.
   - [ ] **4.2** Ensure activating an NPC list item opens the NPC editor tab.

--- a/Scripts/Gamedata/DNpc.gd
+++ b/Scripts/Gamedata/DNpc.gd
@@ -28,9 +28,21 @@ func _init(data: Dictionary, myparent: DNpcs):
 
 func get_data() -> Dictionary:
 	return {
-		"id": id,
-		"name": name,
-		"description": description,
-		"sprite": spriteid,
-		"health": health
+	"id": id,
+	"name": name,
+	"description": description,
+	"sprite": spriteid,
+	"health": health
 	}
+
+# Persist this NPC to disk through the parent container
+func save_to_disk():
+	parent.save_npcs_to_disk()
+
+	# Data has changed; propagate save to parent container
+func changed(_olddata: DNpc):
+	parent.save_npcs_to_disk()
+	
+# Delete handler - currently no references to clean up
+func delete():
+	parent.save_npcs_to_disk()

--- a/Scripts/Gamedata/DNpcs.gd
+++ b/Scripts/Gamedata/DNpcs.gd
@@ -2,6 +2,7 @@ class_name DNpcs
 extends RefCounted
 
 var npc_path: String = "./Mods/Core/Npcs/"
+var file_path: String = npc_path + "Npcs.json"
 var npcdict: Dictionary = {}
 var sprites: Dictionary = {}
 var mod_id: String = "Core"
@@ -9,6 +10,7 @@ var mod_id: String = "Core"
 func _init(new_mod_id: String) -> void:
 	mod_id = new_mod_id
 	npc_path = "./Mods/" + mod_id + "/Npcs/"
+	file_path = npc_path + "Npcs.json"
 	load_sprites()
 	load_npcs_from_disk()
 
@@ -41,3 +43,26 @@ func sprite_by_id(npcid: String) -> Texture:
 
 func sprite_by_file(spritefile: String) -> Texture:
 	return sprites.get(spritefile, null)
+
+# Save all NPC data to disk
+func save_npcs_to_disk() -> void:
+	var save_data: Array = []
+	for npc in npcdict.values():
+		save_data.append(npc.get_data())
+		Helper.json_helper.write_json_file(file_path, JSON.stringify(save_data, "\t"))
+
+# Add a new NPC with the given ID
+func add_new(newid: String) -> void:
+	append_new(DNpc.new({"id": newid}, self))
+
+# Append an existing NPC to the dictionary and persist
+func append_new(newnpc: DNpc) -> void:
+	npcdict[newnpc.id] = newnpc
+	save_npcs_to_disk()
+
+# Delete an NPC by its ID and save changes
+func delete_by_id(npcid: String) -> void:
+	if npcdict.has(npcid):
+		npcdict[npcid].delete()
+		npcdict.erase(npcid)
+		save_npcs_to_disk()


### PR DESCRIPTION
## Summary
- add persistence methods to DNpc
- implement CRUD helpers in DNpcs
- mark related tasks as committed

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_6879286326948325b287a7006732884d