### PR TITLE
Address task list for signal cleanup

### DIFF
--- a/.project-management/current-prd/tasks-prd.refactor-readability.md
+++ b/.project-management/current-prd/tasks-prd.refactor-readability.md
@@ -45,6 +45,14 @@
 │   ├── Catax_itemgroup_editor.png
 ```
 
+## Relevant Files
+
+### Existing Files Modified
+- `Scripts/Helper/quest_helper.gd` - Standardize signal connection checks.
+- `Scripts/BuildManager.gd` - Prevent duplicate signal connections.
+- `Scripts/Mob/MobAttack.gd` - Remove unused variable.
+- `.project-management/current-prd/tasks-prd.refactor-readability.md` - Update task statuses.
+
 ### Files To Remove
 - *(none)*
 
@@ -52,8 +60,8 @@
 - Unit tests should typically be placed in `/Tests/Unit/`.
 
 ## Tasks
-- [ ] 4.0 Standardize signal connections and remove unused code
-  - [ ] 4.1 Audit scripts for duplicate signal connections
-  - [ ] 4.2 Remove stale variables and unreachable code paths
+- [c] 4.0 Standardize signal connections and remove unused code
+  - [c] 4.1 Audit scripts for duplicate signal connections
+  - [c] 4.2 Remove stale variables and unreachable code paths
 
 *End of document*

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -11,8 +11,10 @@ var construction_choice: String = ""
 
 func _ready():
 	# Connect the build menu visibility_changed signal to a local method
-	Helper.signal_broker.build_window_visibility_changed.connect(_on_build_menu_visibility_change)
-	Helper.signal_broker.construction_chosen.connect(_on_hud_construction_chosen)
+	if not Helper.signal_broker.build_window_visibility_changed.is_connected(_on_build_menu_visibility_change):
+		Helper.signal_broker.build_window_visibility_changed.connect(_on_build_menu_visibility_change)
+	if not Helper.signal_broker.construction_chosen.is_connected(_on_hud_construction_chosen):
+		Helper.signal_broker.construction_chosen.connect(_on_hud_construction_chosen)
 
 func _process(_delta):
 	if is_building:

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -49,47 +49,47 @@ func _ready():
 func connect_signals() -> void:
 	# Connect to the Helper.signal_broker.game_started signal
 	if not Helper.signal_broker.game_started.is_connected(_on_game_started):
-	       Helper.signal_broker.game_started.connect(_on_game_started)
+		Helper.signal_broker.game_started.connect(_on_game_started)
 	if not Helper.signal_broker.game_ended.is_connected(_on_game_ended):
-	       Helper.signal_broker.game_ended.connect(_on_game_ended)
+		Helper.signal_broker.game_ended.connect(_on_game_ended)
 
 	# Connect to the Helper.signal_broker.game_loaded signal
 	if not Helper.signal_broker.game_loaded.is_connected(_on_game_loaded):
-	       Helper.signal_broker.game_loaded.connect(_on_game_loaded)
+		Helper.signal_broker.game_loaded.connect(_on_game_loaded)
 
 	# Connect to misc game event signals
 	if not Helper.signal_broker.mob_killed.is_connected(_on_mob_killed):
-	       Helper.signal_broker.mob_killed.connect(_on_mob_killed)
+		Helper.signal_broker.mob_killed.connect(_on_mob_killed)
 	if not Helper.overmap_manager.player_coord_changed.is_connected(_on_map_entered):
-	       Helper.overmap_manager.player_coord_changed.connect(_on_map_entered)
+		Helper.overmap_manager.player_coord_changed.connect(_on_map_entered)
 	if not ItemManager.craft_successful.is_connected(_on_craft_successful):
-	       ItemManager.craft_successful.connect(_on_craft_successful)
+		ItemManager.craft_successful.connect(_on_craft_successful)
 
 
 	# Connect to the QuestManager signals
 	if not QuestManager.quest_completed.is_connected(_on_quest_complete):
-	       QuestManager.quest_completed.connect(_on_quest_complete)
+		QuestManager.quest_completed.connect(_on_quest_complete)
 	if not QuestManager.quest_failed.is_connected(_on_quest_failed):
-	       QuestManager.quest_failed.connect(_on_quest_failed)
+		QuestManager.quest_failed.connect(_on_quest_failed)
 	if not QuestManager.step_complete.is_connected(_on_step_complete):
-	       QuestManager.step_complete.connect(_on_step_complete)
+		QuestManager.step_complete.connect(_on_step_complete)
 	if not QuestManager.next_step.is_connected(_on_next_step):
-	       QuestManager.next_step.connect(_on_next_step)
+		QuestManager.next_step.connect(_on_next_step)
 	if not QuestManager.step_updated.is_connected(_on_step_updated):
-	       QuestManager.step_updated.connect(_on_step_updated)
+		QuestManager.step_updated.connect(_on_step_updated)
 	if not QuestManager.new_quest_added.is_connected(_on_new_quest_added):
-	       QuestManager.new_quest_added.connect(_on_new_quest_added)
+		QuestManager.new_quest_added.connect(_on_new_quest_added)
 	if not QuestManager.quest_reset.is_connected(_on_quest_reset):
-	       QuestManager.quest_reset.connect(_on_quest_reset)
+		QuestManager.quest_reset.connect(_on_quest_reset)
 
 	# When the user has pressed the "track" button in the quest window
 	if not Helper.signal_broker.track_quest_clicked.is_connected(_on_quest_window_track_quest_clicked):
-	       Helper.signal_broker.track_quest_clicked.connect(_on_quest_window_track_quest_clicked)
+		Helper.signal_broker.track_quest_clicked.connect(_on_quest_window_track_quest_clicked)
 	# Connect equipment signals
 	if not Helper.signal_broker.item_was_equipped.is_connected(_on_item_was_equipped):
-	       Helper.signal_broker.item_was_equipped.connect(_on_item_was_equipped)
+		Helper.signal_broker.item_was_equipped.connect(_on_item_was_equipped)
 	if not Helper.signal_broker.item_was_unequipped.is_connected(_on_item_was_unequipped):
-	       Helper.signal_broker.item_was_unequipped.connect(_on_item_was_unequipped)
+		Helper.signal_broker.item_was_unequipped.connect(_on_item_was_unequipped)
 
 
 func connect_inventory_signals() -> void:

--- a/Scripts/Helper/quest_helper.gd
+++ b/Scripts/Helper/quest_helper.gd
@@ -48,32 +48,48 @@ func _ready():
 # Connect signals for game start, load, end, mob killed, and quest events
 func connect_signals() -> void:
 	# Connect to the Helper.signal_broker.game_started signal
-	Helper.signal_broker.game_started.connect(_on_game_started)
-	Helper.signal_broker.game_ended.connect(_on_game_ended)
-	
+	if not Helper.signal_broker.game_started.is_connected(_on_game_started):
+	       Helper.signal_broker.game_started.connect(_on_game_started)
+	if not Helper.signal_broker.game_ended.is_connected(_on_game_ended):
+	       Helper.signal_broker.game_ended.connect(_on_game_ended)
+
 	# Connect to the Helper.signal_broker.game_loaded signal
-	Helper.signal_broker.game_loaded.connect(_on_game_loaded)
-	
+	if not Helper.signal_broker.game_loaded.is_connected(_on_game_loaded):
+	       Helper.signal_broker.game_loaded.connect(_on_game_loaded)
+
 	# Connect to misc game event signals
-	Helper.signal_broker.mob_killed.connect(_on_mob_killed)
-	Helper.overmap_manager.player_coord_changed.connect(_on_map_entered)
-	ItemManager.craft_successful.connect(_on_craft_successful)
-	
-	
+	if not Helper.signal_broker.mob_killed.is_connected(_on_mob_killed):
+	       Helper.signal_broker.mob_killed.connect(_on_mob_killed)
+	if not Helper.overmap_manager.player_coord_changed.is_connected(_on_map_entered):
+	       Helper.overmap_manager.player_coord_changed.connect(_on_map_entered)
+	if not ItemManager.craft_successful.is_connected(_on_craft_successful):
+	       ItemManager.craft_successful.connect(_on_craft_successful)
+
+
 	# Connect to the QuestManager signals
-	QuestManager.quest_completed.connect(_on_quest_complete)
-	QuestManager.quest_failed.connect(_on_quest_failed)
-	QuestManager.step_complete.connect(_on_step_complete)
-	QuestManager.next_step.connect(_on_next_step)
-	QuestManager.step_updated.connect(_on_step_updated)
-	QuestManager.new_quest_added.connect(_on_new_quest_added)
-	QuestManager.quest_reset.connect(_on_quest_reset)
-	
+	if not QuestManager.quest_completed.is_connected(_on_quest_complete):
+	       QuestManager.quest_completed.connect(_on_quest_complete)
+	if not QuestManager.quest_failed.is_connected(_on_quest_failed):
+	       QuestManager.quest_failed.connect(_on_quest_failed)
+	if not QuestManager.step_complete.is_connected(_on_step_complete):
+	       QuestManager.step_complete.connect(_on_step_complete)
+	if not QuestManager.next_step.is_connected(_on_next_step):
+	       QuestManager.next_step.connect(_on_next_step)
+	if not QuestManager.step_updated.is_connected(_on_step_updated):
+	       QuestManager.step_updated.connect(_on_step_updated)
+	if not QuestManager.new_quest_added.is_connected(_on_new_quest_added):
+	       QuestManager.new_quest_added.connect(_on_new_quest_added)
+	if not QuestManager.quest_reset.is_connected(_on_quest_reset):
+	       QuestManager.quest_reset.connect(_on_quest_reset)
+
 	# When the user has pressed the "track" button in the quest window
-	Helper.signal_broker.track_quest_clicked.connect(_on_quest_window_track_quest_clicked)
+	if not Helper.signal_broker.track_quest_clicked.is_connected(_on_quest_window_track_quest_clicked):
+	       Helper.signal_broker.track_quest_clicked.connect(_on_quest_window_track_quest_clicked)
 	# Connect equipment signals
-	Helper.signal_broker.item_was_equipped.connect(_on_item_was_equipped)
-	Helper.signal_broker.item_was_unequipped.connect(_on_item_was_unequipped)
+	if not Helper.signal_broker.item_was_equipped.is_connected(_on_item_was_equipped):
+	       Helper.signal_broker.item_was_equipped.connect(_on_item_was_equipped)
+	if not Helper.signal_broker.item_was_unequipped.is_connected(_on_item_was_unequipped):
+	       Helper.signal_broker.item_was_unequipped.connect(_on_item_was_unequipped)
 
 
 func connect_inventory_signals() -> void:

--- a/Scripts/Mob/MobAttack.gd
+++ b/Scripts/Mob/MobAttack.gd
@@ -4,7 +4,6 @@ class_name MobAttack
 var attack_timer: Timer
 var mob: CharacterBody3D # The mob that we execute the attack for
 
-var tween: Tween
 var spotted_target: CharacterBody3D # This mob's current target for combat
 var is_in_attack_mode = false
 


### PR DESCRIPTION
## Summary
- standardize how signals are connected in `quest_helper.gd`
- guard signal connections in `BuildManager.gd`
- remove unused variable from `MobAttack.gd`
- mark related tasks committed

## Testing
- `godot --headless --import` *(fails: Parse Error)*

------
https://chatgpt.com/codex/tasks/task_e_68794a790b748325ae257e1cf10dd5d4