### PR TITLE
Refactor BuildManager for readability

### DIFF
--- a/.project-management/current-prd/tasks-refactor-readability.md
+++ b/.project-management/current-prd/tasks-refactor-readability.md
@@ -65,9 +65,9 @@
 - Unit tests should typically be placed in `/Tests/Unit/`.
 
 ## Tasks
-- [ ] **2.0 Improve `BuildManager.gd` readability**
-  - [ ] 2.1 Document all public functions with brief comments.
-  - [ ] 2.2 Replace magic numbers with named constants.
-  - [ ] 2.3 Consolidate duplicate debug logging.
+- [x] **2.0 Improve `BuildManager.gd` readability**
+  - [x] 2.1 Document all public functions with brief comments.
+  - [x] 2.2 Replace magic numbers with named constants.
+  - [x] 2.3 Consolidate duplicate debug logging.
 
 *End of document*

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -150,8 +150,7 @@ func set_building_state(isvisible: bool):
 	log_debug("Set building state: %s" % str(isvisible))
 
 
-# Updates the material of the construction ghost based on the construction type and choice
-# Update ghost material and sizing
+# Updates the material and size of the construction ghost based on the construction type and choice
 func update_construction_ghost():
 	construction_ghost.reset_to_default() # Resets size, rotation, material, offset
 	if construction_type == "furniture":
@@ -180,4 +179,3 @@ func calculate_furniture_size(rfurniture: RFurniture) -> Vector2:
 		var sprite_depth = sprite_texture.get_height() / TEXTURE_SCALE # Convert pixels to meters
 		return Vector2(sprite_width, sprite_depth)  # Use height from support shape
 	return DEFAULT_FURNITURE_SIZE  # Default size if texture is not set
-

--- a/Scripts/BuildManager.gd
+++ b/Scripts/BuildManager.gd
@@ -6,22 +6,40 @@ var is_building = false
 var construction_type: String = "block"
 var construction_choice: String = ""
 
+const CHUNK_SIZE := 32
+const PLANK_COST := 2
+const ROTATION_90 := 90
+const ROTATION_270 := 270
+const TEXTURE_SCALE := 100.0
+const DEFAULT_FURNITURE_SIZE := Vector2(0.5, 0.5)
+const FURNITURE_Y_OFFSET := 1
+
+func log_debug(message: String) -> void:
+	print_debug("[BuildManager] %s" % message)
+
+func log_unknown_construction_type() -> void:
+	log_debug("Unknown construction type: %s" % construction_type)
+
 @export var level_generator: Node3D
 @export var hud: NodePath
 
+# Called when the node enters the scene
 func _ready():
 	# Connect the build menu visibility_changed signal to a local method
 	Helper.signal_broker.build_window_visibility_changed.connect(_on_build_menu_visibility_change)
 	Helper.signal_broker.construction_chosen.connect(_on_hud_construction_chosen)
 
+# Keep the ghost visible while building
 func _process(_delta):
 	if is_building:
 		construction_ghost.visible = true
 
+# Cancel construction with right-click
 func _input(event: InputEvent):
 	if event.is_action_pressed("click_right") and is_building:
 		cancel_building()
 
+# Reset building state and hide the ghost
 func cancel_building():
 	is_building = false
 	General.is_allowed_to_shoot = true
@@ -31,6 +49,7 @@ func cancel_building():
 
 # When the user selects an option in the BuildingMenu.tscn scene
 # type: One of "block" or "furniture". Choice: can be "concrete_wall" or some furniture id
+# Receive construction selection from HUD
 func _on_hud_construction_chosen(type: String, choice: String):
 	construction_type = type
 	construction_choice = choice
@@ -38,19 +57,21 @@ func _on_hud_construction_chosen(type: String, choice: String):
 	start_building()
 
 
+# Begin building mode
 func start_building():
 	is_building = true
 	General.is_allowed_to_shoot = false
 	construction_ghost.visible = true
-	print_debug("Start building: type = ", construction_type, ", choice = ", construction_choice)
+	log_debug("Start building: type = %s, choice = %s" % [construction_type, construction_choice])
 
 
-# Connects from the ConstructionGhost.gd script. 
+# Connects from the ConstructionGhost.gd script.
 # Example construction data: {"pos": global_transform.origin}
+# Handle user click on construction ghost
 func on_construction_clicked(construction_data: Dictionary):
 	# Ensure construction_type and construction_choice are set
 	if construction_type == "" or construction_choice == "":
-		print_debug("Construction type or choice is not set. Aborting.")
+		log_debug("Construction type or choice is not set. Aborting.")
 		return
 
 	var chunk: Chunk = level_generator.get_chunk_from_position(construction_data.pos)
@@ -63,29 +84,30 @@ func on_construction_clicked(construction_data: Dictionary):
 		"furniture":
 			handle_furniture_construction(construction_data, chunk)
 		_:
-			print_debug("Unknown construction type: ", construction_type)
-
+			log_unknown_construction_type()
+# Build a block at the specified location
 func handle_block_construction(construction_data: Dictionary, chunk: Chunk) -> void:
 	var numberofplanks: int = ItemManager.get_accessibleitem_amount("plank_2x4")
-	if numberofplanks < 2:
-		print_debug("Tried to construct, but not enough planks")
+	if numberofplanks < PLANK_COST:
+		log_debug("Tried to construct, but not enough planks")
 		return
 
-	if not ItemManager.remove_resource("plank_2x4", 2, ItemManager.allAccessibleItems):
+	if not ItemManager.remove_resource("plank_2x4", PLANK_COST, ItemManager.allAccessibleItems):
 		return
 
 	var local_position = calculate_local_position(construction_data.pos, chunk.position)
 	chunk.add_block("concrete_00", local_position)
-	print_debug("Block placed at local position: ", local_position, " in chunk at ", chunk.position, " with type concrete_00")
+	log_debug("Block placed at local position: %s in chunk at %s with type concrete_00" % [local_position, chunk.position])
 
+# Spawn furniture in the chunk based on selection
 func handle_furniture_construction(construction_data: Dictionary, chunk: Chunk) -> void:
-	construction_data.pos.y -= 1
+	construction_data.pos.y -= FURNITURE_Y_OFFSET
 	# Because Godot can be strange with rotation sometimes we have to translate the rotation
 	var myrotation = construction_data.rotation
-	if myrotation == 90:
-		myrotation = 270
-	elif myrotation == 270:
-		myrotation = 90
+	if myrotation == ROTATION_90:
+		myrotation = ROTATION_270
+	elif myrotation == ROTATION_270:
+		myrotation = ROTATION_90
 
 	# Translate the position to negate the chunk's `mypos`
 	construction_data.pos -= chunk.mypos
@@ -95,22 +117,18 @@ func handle_furniture_construction(construction_data: Dictionary, chunk: Chunk) 
 		"json": {"id": construction_choice, "rotation": myrotation, "mode": "blueprint"},
 		"pos": construction_data.pos
 	})
+	log_debug("Furniture construction chosen. Type: %s, Choice: %s, Adjusted construction_data.pos: %s" % [construction_type, construction_choice, str(construction_data.pos)])
 
-	print_debug(
-		"Furniture construction chosen. Type: ", construction_type,
-		", Choice: ", construction_choice,
-		", Adjusted construction_data.pos: ", str(construction_data.pos)
-	)
-
-
+# Convert a world position to chunk-local coordinates
 func calculate_local_position(global_pos: Vector3, chunk_pos: Vector3) -> Vector3:
 	# Calculate local position within the chunk
-	var local_x = int(global_pos.x - chunk_pos.x) % 32
-	var local_z = int(global_pos.z - chunk_pos.z) % 32
+	var local_x = int(global_pos.x - chunk_pos.x) % CHUNK_SIZE
+	var local_z = int(global_pos.z - chunk_pos.z) % CHUNK_SIZE
 	return Vector3(local_x, global_pos.y, local_z)
 
+# React to build menu visibility changes
 func _on_build_menu_visibility_change(buildmenu):
-	print_debug("Build menu visibility changed: ", buildmenu.is_visible())
+	log_debug("Build menu visibility changed: %s" % buildmenu.is_visible())
 	if buildmenu.is_visible():
 		if !is_building:
 			var selection: Dictionary = buildmenu.get_selected_type_and_choice()
@@ -123,15 +141,17 @@ func _on_build_menu_visibility_change(buildmenu):
 	else:
 		set_building_state(false)
 
+# Toggle building mode visuals and state
 func set_building_state(isvisible: bool):
 	construction_ghost.visible = isvisible
 	is_building = isvisible
 	if not isvisible:
 		General.is_allowed_to_shoot = true
-	print_debug("Set building state: ", isvisible)
+	log_debug("Set building state: %s" % str(isvisible))
 
 
 # Updates the material of the construction ghost based on the construction type and choice
+# Update ghost material and sizing
 func update_construction_ghost():
 	construction_ghost.reset_to_default() # Resets size, rotation, material, offset
 	if construction_type == "furniture":
@@ -145,17 +165,19 @@ func update_construction_ghost():
 			if not rfurniture.edgesnapping == "None":
 				construction_ghost.set_position_offset(rfurniture.edgesnapping)
 		else:
-			print_debug("RFurniture with ID ", construction_choice, " not found. Resetting material.")
+			log_debug("RFurniture with ID %s not found. Resetting material." % construction_choice)
 	else:
 		# Handle unknown construction types by resetting to the default material
-		print_debug("Unknown construction type: ", construction_type, ". Resetting material.")
+		log_unknown_construction_type()
 
 
 # Function to calculate the size of the furniture
+# Determine furniture mesh size from sprite
 func calculate_furniture_size(rfurniture: RFurniture) -> Vector2:
 	var sprite_texture = rfurniture.sprite
 	if sprite_texture:
-		var sprite_width = sprite_texture.get_width() / 100.0 # Convert pixels to meters
-		var sprite_depth = sprite_texture.get_height() / 100.0 # Convert pixels to meters
+		var sprite_width = sprite_texture.get_width() / TEXTURE_SCALE # Convert pixels to meters
+		var sprite_depth = sprite_texture.get_height() / TEXTURE_SCALE # Convert pixels to meters
 		return Vector2(sprite_width, sprite_depth)  # Use height from support shape
-	return Vector2(0.5, 0.5)  # Default size if texture is not set
+	return DEFAULT_FURNITURE_SIZE  # Default size if texture is not set
+


### PR DESCRIPTION
## Summary
- document BuildManager methods
- replace magic numbers with constants
- add unified debug logging helpers
- update tasks list

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_6879c20299e88325951c93a226fb74cf