### PR TITLE
Add spawn_maps to NPC models

### DIFF
--- a/.project-management/current-prd/tasks-prd-npc-spawn-maps.md
+++ b/.project-management/current-prd/tasks-prd-npc-spawn-maps.md
@@ -105,11 +105,11 @@
 - Use GDScript 4.4 syntax with tabs and follow patterns from `overmap_area_region_editor.gd`
 
 ## Tasks
-- [ ] **1.0 Add `spawn_maps` array to NPC data structures**
-  - [ ] 1.1 Extend `DNpc.gd` with a `spawn_maps` Array property and default empty array
-  - [ ] 1.2 Load `spawn_maps` from JSON in `DNpc._init`
-  - [ ] 1.3 Include `spawn_maps` in `DNpc.get_data`
-  - [ ] 1.4 Mirror property in `RNpc.gd` and copy values in `overwrite_from_dnpc`
+- [x] **1.0 Add `spawn_maps` array to NPC data structures**
+  - [x] 1.1 Extend `DNpc.gd` with a `spawn_maps` Array property and default empty array
+  - [x] 1.2 Load `spawn_maps` from JSON in `DNpc._init`
+  - [x] 1.3 Include `spawn_maps` in `DNpc.get_data`
+  - [x] 1.4 Mirror property in `RNpc.gd` and copy values in `overwrite_from_dnpc`
 - [ ] **2.0 Implement spawn map UI in NpcEditor**
   - [ ] 2.1 Add a GridContainer named `SpawnMapsGrid` to `NpcEditor.tscn`
   - [ ] 2.2 Populate entries with sprite preview, map id label, weight SpinBox and delete button

--- a/Scripts/Gamedata/DNpc.gd
+++ b/Scripts/Gamedata/DNpc.gd
@@ -17,6 +17,8 @@ var spriteid: String
 var sprite: Texture
 var health: int = 100
 var parent: DNpcs
+var spawn_maps: Array = []
+
 
 func _init(data: Dictionary, myparent: DNpcs):
 	parent = myparent
@@ -25,24 +27,31 @@ func _init(data: Dictionary, myparent: DNpcs):
 	description = data.get("description", "")
 	spriteid = data.get("sprite", "")
 	health = data.get("health", 100)
+	spawn_maps = data.get("spawn_maps", [])
+
 
 func get_data() -> Dictionary:
 	return {
-	"id": id,
-	"name": name,
-	"description": description,
-	"sprite": spriteid,
-	"health": health
+		"id": id,
+		"name": name,
+		"description": description,
+		"sprite": spriteid,
+		"health": health,
+		"spawn_maps": spawn_maps
 	}
+
 
 # Persist this NPC to disk through the parent container
 func save_to_disk():
 	parent.save_npcs_to_disk()
 
 	# Data has changed; propagate save to parent container
+
+
 func changed(_olddata: DNpc):
 	parent.save_npcs_to_disk()
-	
+
+
 # Delete handler - currently no references to clean up
 func delete():
 	parent.save_npcs_to_disk()

--- a/Scripts/Runtimedata/RNpc.gd
+++ b/Scripts/Runtimedata/RNpc.gd
@@ -8,10 +8,13 @@ var spriteid: String
 var sprite: Texture
 var health: int
 var parent: RNpcs
+var spawn_maps: Array = []
+
 
 func _init(myparent: RNpcs, newid: String):
 	parent = myparent
 	id = newid
+
 
 func overwrite_from_dnpc(dnpc: DNpc) -> void:
 	if id != dnpc.id:
@@ -21,6 +24,8 @@ func overwrite_from_dnpc(dnpc: DNpc) -> void:
 	spriteid = dnpc.spriteid
 	sprite = dnpc.sprite
 	health = dnpc.health
+	spawn_maps = dnpc.spawn_maps.duplicate(true)
+
 
 func get_data() -> Dictionary:
 	return {
@@ -28,5 +33,6 @@ func get_data() -> Dictionary:
 		"name": name,
 		"description": description,
 		"sprite": spriteid,
-		"health": health
+		"health": health,
+		"spawn_maps": spawn_maps
 	}


### PR DESCRIPTION
## Summary
- extend `DNpc` and `RNpc` with new `spawn_maps` array
- load and save spawn maps in NPC get/set methods
- mark first task group complete in task list

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_6879eeb3667c8325bfb8151fe139e900