### PR TITLE
Add maintenance subtasks for lore review

### DIFF
--- a/.project-management/current-prd/tasks-lore-design-review.md
+++ b/.project-management/current-prd/tasks-lore-design-review.md
@@ -1,0 +1,86 @@
+## Selected maintenance goal
+- Lore & Design Implementation Review
+
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Assets
+│   └── Fonts
+├── Defaults
+│   ├── Blocks
+│   ├── Mobs
+│   ├── Player
+│   ├── Projectiles
+│   ├── Shaders
+│   └── Sprites
+├── FeatureList.md
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── Mods
+│   ├── Backrooms
+│   ├── Core
+│   ├── Dimensionfall
+│   └── Test
+├── README.md
+├── Scenes
+│   ├── ContentManager
+│   ├── GameOver.tscn
+│   ├── InventoryContainerListItem.tscn
+│   ├── InventoryWindow.tscn
+│   ├── LoadingScreen.tscn
+│   ├── Overmap
+│   ├── UI
+│   ├── input_manager.tscn
+│   └── player.tscn
+├── Scripts
+│   ├── AttributesWindow.gd
+│   ├── AttributesWindow.gd.uid
+│   ├── BuildManager.gd
+│   ├── BuildManager.gd.uid
+```
+
+## Relevant Files
+- `Documentation/Game_design/Lore.md` - World lore and setting overview
+- `FeatureList.md` - High-level features and roadmap information
+- `Mods/Dimensionfall/Items/Items.json` - Core item definitions
+- `Mods/Dimensionfall/Quests/Quests.json` - Quest definitions and narrative content
+- `README.md` - Contains roadmap and general project information
+
+### Proposed New Files
+- `Documentation/Game_design/lore_consistency_checklist.md` - Guidelines to keep content consistent with lore
+
+### Existing Files Modified
+- `Documentation/Game_design/Lore.md` - Add references to quests and factions
+- `Mods/Dimensionfall/Items/Items.json` - Adjust item descriptions for lore consistency
+- `Mods/Dimensionfall/Quests/Quests.json` - Update quest text for narrative alignment
+- `README.md` - Expand roadmap with narrative milestones
+
+### Files To Remove
+- None
+
+### Notes
+- Unit tests should typically be placed in `/Tests/Unit/`.
+
+## Tasks
+- [ ] 1.0 Review item definitions for lore alignment
+  - [ ] 1.1 Identify items with missing or outdated lore references
+  - [ ] 1.2 Cross-check item descriptions against `Documentation/Game_design/Lore.md`
+  - [ ] 1.3 Document required changes in `Mods/Dimensionfall/Items/Items.json`
+- [ ] 2.0 Review quests for consistency with lore
+  - [ ] 2.1 Compare quest narratives with major lore events and factions
+  - [ ] 2.2 Update quest text in `Mods/Dimensionfall/Quests/Quests.json`
+- [ ] 3.0 Update lore documentation with implemented features
+  - [ ] 3.1 Add descriptions for new quests and factions
+  - [ ] 3.2 Ensure the timeline reflects recent content additions
+- [ ] 4.0 Expand roadmap with narrative components
+  - [ ] 4.1 Outline upcoming storyline arcs in `README.md`
+  - [ ] 4.2 Highlight planned modding support for lore content
+- [ ] 5.0 Create lore consistency checklist for contributors
+  - [ ] 5.1 Draft guidelines for referencing established lore elements
+  - [ ] 5.2 Include steps to verify additions against the checklist

--- a/.project-management/current-prd/tasks-lore-design-review.md
+++ b/.project-management/current-prd/tasks-lore-design-review.md
@@ -52,14 +52,10 @@
 - `Mods/Dimensionfall/Quests/Quests.json` - Quest definitions and narrative content
 - `README.md` - Contains roadmap and general project information
 
-### Proposed New Files
-- `Documentation/Game_design/lore_consistency_checklist.md` - Guidelines to keep content consistent with lore
 
 ### Existing Files Modified
-- `Documentation/Game_design/Lore.md` - Add references to quests and factions
 - `Mods/Dimensionfall/Items/Items.json` - Adjust item descriptions for lore consistency
 - `Mods/Dimensionfall/Quests/Quests.json` - Update quest text for narrative alignment
-- `README.md` - Expand roadmap with narrative milestones
 
 ### Files To Remove
 - None
@@ -75,12 +71,3 @@
 - [ ] 2.0 Review quests for consistency with lore
   - [ ] 2.1 Compare quest narratives with major lore events and factions
   - [ ] 2.2 Update quest text in `Mods/Dimensionfall/Quests/Quests.json`
-- [ ] 3.0 Update lore documentation with implemented features
-  - [ ] 3.1 Add descriptions for new quests and factions
-  - [ ] 3.2 Ensure the timeline reflects recent content additions
-- [ ] 4.0 Expand roadmap with narrative components
-  - [ ] 4.1 Outline upcoming storyline arcs in `README.md`
-  - [ ] 4.2 Highlight planned modding support for lore content
-- [ ] 5.0 Create lore consistency checklist for contributors
-  - [ ] 5.1 Draft guidelines for referencing established lore elements
-  - [ ] 5.2 Include steps to verify additions against the checklist


### PR DESCRIPTION
## Summary
- expand lore review tasks with actionable sub-tasks

## Testing
- `godot --headless --import` *(fails: Unrecognized UID)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: resource loading errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a2475d85c8325a3eb655a263390d2