### PR TITLE
Add maintenance sub-tasks

### DIFF
--- a/.project-management/current-prd/tasks-bug-logic-maintenance.md
+++ b/.project-management/current-prd/tasks-bug-logic-maintenance.md
@@ -1,0 +1,201 @@
+## Selected maintenance goal
+- Bug & Logic Error Identification
+
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Assets
+│   └── Fonts
+├── Defaults
+│   ├── Blocks
+│   ├── Mobs
+│   ├── Player
+│   ├── Projectiles
+│   ├── Shaders
+│   └── Sprites
+├── Documentation
+│   ├── Game_design
+│   ├── Game_development
+│   └── Modding
+├── FeatureList.md
+├── Images
+│   ├── Icons
+│   └── Main menu
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── Media
+│   ├── Catax_basic.png
+│   ├── Catax_basic.png.import
+│   ├── Catax_basic_zoomed_out.png
+│   ├── Catax_basic_zoomed_out.png.import
+│   ├── Catax_content_editor.png
+│   ├── Catax_content_editor.png.import
+│   ├── Catax_crafting_editor.png
+│   ├── Catax_crafting_editor.png.import
+│   ├── Catax_furniture_editor.png
+│   ├── Catax_furniture_editor.png.import
+│   ├── Catax_item_editor.png
+│   ├── Catax_item_editor.png.import
+│   ├── Catax_itemgroup_editor.png
+│   ├── Catax_itemgroup_editor.png.import
+│   ├── Catax_map_editor.png
+│   ├── Catax_map_editor.png.import
+│   ├── Catax_map_editor_area_editor.png
+│   ├── Catax_map_editor_area_editor.png.import
+│   ├── Catax_map_editor_areas.png
+│   ├── Catax_map_editor_areas.png.import
+│   ├── Catax_map_editor_preview.png
+│   ├── Catax_map_editor_preview.png.import
+│   ├── Catax_mob_editor.png
+│   ├── Catax_mob_editor.png.import
+│   ├── Catax_overmap_large.png
+│   ├── Catax_overmap_large.png.import
+│   ├── Catax_playerattribute_editor.png
+│   ├── Catax_playerattribute_editor.png.import
+│   ├── Catax_quest_editor.png
+│   ├── Catax_quest_editor.png.import
+│   ├── Catax_skills_editor.png
+│   ├── Catax_skills_editor.png.import
+│   ├── Catax_stats_editor.png
+│   ├── Catax_stats_editor.png.import
+│   ├── Catax_tacticalmap_editor.png
+│   ├── Catax_tacticalmap_editor.png.import
+│   ├── Catax_tile_editor.png
+│   ├── Catax_tile_editor.png.import
+│   ├── Catax_wearableslots_editor.png
+│   ├── Catax_wearableslots_editor.png.import
+│   ├── Dimensionfall_add_remove_mod_menu.png
+│   ├── Dimensionfall_add_remove_mod_menu.png.import
+│   ├── Dimensionfall_crafting_station.png
+│   ├── Dimensionfall_crafting_station.png.import
+│   ├── Dimensionfall_inventory.png
+│   ├── Dimensionfall_inventory.png.import
+│   ├── Dimensionfall_main_menu.png
+│   ├── Dimensionfall_main_menu.png.import
+│   ├── Dimensionfall_mobfaction_editor.png
+│   ├── Dimensionfall_mobfaction_editor.png.import
+│   ├── Dimensionfall_mobgroup_editor.png
+│   ├── Dimensionfall_mobgroup_editor.png.import
+│   ├── Dimensionfall_overmap.png
+│   ├── Dimensionfall_overmap.png.import
+│   ├── Dimensionfall_overmaparea_editor.png
+│   ├── Dimensionfall_overmaparea_editor.png.import
+│   ├── Dimensionfall_overmaparea_generator.png
+│   ├── Dimensionfall_overmaparea_generator.png.import
+│   ├── Dimensionfall_quest_journal.png
+│   └── Dimensionfall_quest_journal.png.import
+├── Mods
+│   ├── Backrooms
+│   ├── Core
+│   ├── Dimensionfall
+│   └── Test
+├── README.md
+├── Scenes
+│   ├── ContentManager
+│   ├── GameOver.tscn
+│   ├── InventoryContainerListItem.tscn
+│   ├── InventoryWindow.tscn
+│   ├── LoadingScreen.tscn
+│   ├── Overmap
+│   ├── UI
+│   ├── input_manager.tscn
+│   └── player.tscn
+├── Scripts
+│   ├── AttributesWindow.gd
+│   ├── AttributesWindow.gd.uid
+│   ├── BuildManager.gd
+│   ├── BuildManager.gd.uid
+│   ├── BuildingMenu.gd
+│   ├── BuildingMenu.gd.uid
+│   ├── Camera.gd
+│   ├── Camera.gd.uid
+│   ├── CharacterWindow.gd
+│   ├── CharacterWindow.gd.uid
+│   ├── Chunk.gd
+│   ├── Chunk.gd.uid
+│   ├── ChunkLevel.gd
+│   ├── ChunkLevel.gd.uid
+│   ├── Client.gd
+│   ├── Client.gd.uid
+│   ├── Components
+│   ├── ConstructionGhost.gd
+│   ├── ConstructionGhost.gd.uid
+│   ├── CraftingMenu.gd
+│   ├── CraftingMenu.gd.uid
+│   ├── CtrlInventoryStackedCustom.gd
+│   ├── CtrlInventoryStackedCustom.gd.uid
+│   ├── CtrlInventoryStackedListItem.gd
+│   ├── CtrlInventoryStackedListItem.gd.uid
+│   ├── CtrlInventoryStackedlistHeaderItem.gd
+│   ├── CtrlInventoryStackedlistHeaderItem.gd.uid
+│   ├── Documentation.gd
+│   ├── Documentation.gd.uid
+│   ├── EquipmentSlot.gd
+│   ├── EquipmentSlot.gd.uid
+│   ├── EquippedItem.gd
+│   ├── EquippedItem.gd.uid
+│   ├── EscapeMenu.gd
+│   ├── EscapeMenu.gd.uid
+│   ├── FurnitureBlueprintSpawner.gd
+│   ├── FurnitureBlueprintSpawner.gd.uid
+│   ├── FurnitureBlueprintSrv.gd
+│   ├── FurnitureBlueprintSrv.gd.uid
+│   ├── FurnitureConstructionWindow.gd
+│   ├── FurnitureConstructionWindow.gd.uid
+│   ├── FurniturePhysicsSpawner.gd
+│   ├── FurniturePhysicsSpawner.gd.uid
+│   ├── FurniturePhysicsSrv.gd
+│   ├── FurniturePhysicsSrv.gd.uid
+│   ├── FurnitureStaticSpawner.gd
+```
+
+## Relevant Files
+- `LevelGenerator.gd`
+- `Scripts/item_manager.gd`
+- `Scripts/general.gd`
+- `Tests/Unit/test_levelgenerator_unload_loop.gd`
+- `Tests/Unit/test_item_manager.gd`
+
+### Proposed New Files
+- `Tests/Unit/test_general_string_to_vector2.gd` - Tests for invalid coordinate parsing.
+
+### Existing Files Modified
+- `LevelGenerator.gd` - Refine chunk queue handling during unload operations.
+- `Scripts/item_manager.gd` - Fix resource removal and magazine reload logic.
+- `Scripts/general.gd` - Make `string_to_vector2` tolerant to malformed input.
+
+### Files To Remove
+- *(none)*
+
+### Notes
+- Unit tests should typically be placed in `/Tests/Unit/`.
+
+## Tasks
+- [ ] 1.0 Ensure chunk unload logic is race-condition free
+  - [ ] 1.1 Review `LevelGenerator.gd` unload logic for asynchronous issues
+  - [ ] 1.2 Implement queue lock to prevent concurrent unloads
+  - [ ] 1.3 Add unit test `test_levelgenerator_unload_loop.gd`
+- [ ] 2.0 Correct inventory resource removal and magazine reload behavior
+  - [ ] 2.1 Inspect `remove_resource` and reload functions for off-by-one errors
+  - [ ] 2.2 Fix decrement logic for ammo and resources
+  - [ ] 2.3 Expand `test_item_manager.gd` coverage
+- [ ] 3.0 Improve coordinate parsing robustness
+  - [ ] 3.1 Update `string_to_vector2` to handle malformed input
+  - [ ] 3.2 Return `Vector2.ZERO` on failure
+  - [ ] 3.3 Add `test_general_string_to_vector2.gd`
+- [ ] 4.0 Audit equipment signal connections
+  - [ ] 4.1 Catalog current equipment connect/disconnect calls
+  - [ ] 4.2 Ensure disconnects occur on unequip
+  - [ ] 4.3 Add comments describing expected signal flow
+- [ ] 5.0 Add regression tests for loading/unloading and inventory operations
+  - [ ] 5.1 Validate repeated load/unload cycles in `LevelGenerator`
+  - [ ] 5.2 Confirm ammo counts after magazine reload sequences
+  - [ ] 5.3 Ensure new tests fail before fixes and pass after
+
+*End of document*


### PR DESCRIPTION
## Summary
- expand task list with detailed subtasks for bug and logic maintenance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a618ff38c83258257dc064fc5409d