### PR TITLE
Add maintenance sub-tasks

### DIFF
--- a/.project-management/current-prd/tasks-maintenance-performance.md
+++ b/.project-management/current-prd/tasks-maintenance-performance.md
@@ -1,0 +1,93 @@
+## Selected maintenance goal
+- Maintainability & Performance Cleanup (Goal 7)
+
+## Pre-Feature Development Project Tree
+```
+.
+├── Assets
+│   └── Fonts
+├── Defaults
+│   ├── Blocks
+│   ├── Mobs
+│   ├── Player
+│   ├── Projectiles
+│   ├── Shaders
+│   └── Sprites
+├── Documentation
+│   ├── Game_design
+│   ├── Game_development
+│   └── Modding
+├── Images
+│   ├── Icons
+│   └── Main menu
+├── Media
+│   ├── Catax_basic.png
+│   ├── Catax_basic.png.import
+│   ├── Catax_basic_zoomed_out.png
+│   ├── Catax_basic_zoomed_out.png.import
+│   ├── Catax_content_editor.png
+│   ├── Catax_content_editor.png.import
+│   ├── Catax_crafting_editor.png
+│   ├── Catax_crafting_editor.png.import
+│   ├── Catax_furniture_editor.png
+│   ├── Catax_furniture_editor.png.import
+│   ├── Catax_item_editor.png
+│   ├── Catax_item_editor.png.import
+│   ├── Catax_itemgroup_editor.png
+│   ├── Catax_itemgroup_editor.png.import
+│   ├── Catax_map_editor.png
+│   ├── Catax_map_editor.png.import
+│   ├── Catax_map_editor_area_editor.png
+│   ├── Catax_map_editor_area_editor.png.import
+│   ├── Catax_map_editor_areas.png
+│   ├── Catax_map_editor_areas.png.import
+│   ├── Catax_map_editor_preview.png
+│   ├── Catax_map_editor_preview.png.import
+```
+
+## Relevant Files
+- `LevelManager.gd`
+- `LevelGenerator.gd`
+- `Scripts/OvermapGrid.gd`
+- `Scripts/Mob/Detection.gd`
+- `Scripts/general.gd`
+
+### Proposed New Files
+- `Scripts/optimization/cache_manager.gd` - Handles cached references to frequently accessed nodes.
+- `Tests/Unit/test_cache_manager.gd` - Unit tests for cache manager behavior.
+- `Tests/Unit/test_chunk_optimization.gd` - Tests for improved chunk loading logic.
+
+### Existing Files Modified
+- `LevelManager.gd` - Cache player reference during `_ready` instead of searching each frame.
+- `Scripts/OvermapGrid.gd` - Refactor path generation loops to reduce duplicate work.
+- `LevelGenerator.gd` - Replace array queues with sets for faster lookup.
+- `Scripts/Mob/Detection.gd` - Cache player list and use signals to update when mobs spawn.
+
+### Files To Remove
+- None identified
+
+### Notes
+- Unit tests should typically be placed in `/Tests/Unit/`.
+
+## Tasks
+- [ ] 1.0 Cache Frequent Node References
+  - [ ] 1.1 Create `Scripts/optimization/cache_manager.gd` for node caching logic
+  - [ ] 1.2 Cache the player reference in `LevelManager.gd` during `_ready`
+  - [ ] 1.3 Cache player lists in `Scripts/Mob/Detection.gd` and connect spawn signals
+  - [ ] 1.4 Add unit tests in `Tests/Unit/test_cache_manager.gd`
+- [ ] 2.0 Optimize Overmap and Chunk Management Loops
+  - [ ] 2.1 Refactor loops in `Scripts/OvermapGrid.gd` to prevent duplicate work
+  - [ ] 2.2 Replace array queues with sets in `LevelGenerator.gd`
+  - [ ] 2.3 Add `Tests/Unit/test_chunk_optimization.gd` for chunk loading logic
+- [ ] 3.0 Remove Unused Signals and Variables
+  - [ ] 3.1 Audit `LevelManager.gd` and `Scripts/OvermapGrid.gd` for unused signals
+  - [ ] 3.2 Remove redundant variables from `Scripts/general.gd`
+  - [ ] 3.3 Update documentation to reflect removed signals
+- [ ] 4.0 Reorganize Scenes and Scripts Structure
+  - [ ] 4.1 Move scenes into categorized folders under `Scenes/`
+  - [ ] 4.2 Align script names with scene names and update references
+  - [ ] 4.3 Update `override.cfg` and `project.godot` paths
+- [ ] 5.0 Add Performance Regression Tests
+  - [ ] 5.1 Create a harness to measure caching and chunk load times
+  - [ ] 5.2 Integrate performance tests into the GUT suite
+  - [ ] 5.3 Document running the tests in `Documentation/Game_development`


### PR DESCRIPTION
## Summary
- add detailed subtasks to maintenance task file

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_687b3c1d18688325b918d88911bd936d