### PR TITLE
Update runtime data reconstruction

### DIFF
--- a/Scenes/ContentManager/OtherTools/Scripts/overmap_grid_visualization.gd
+++ b/Scenes/ContentManager/OtherTools/Scripts/overmap_grid_visualization.gd
@@ -32,10 +32,10 @@ func generate_grid():
 
 			# Check if there is a tile at the current position in mygrid
 			if mygrid.cells.has(current_position):
-				var map_cell = mygrid.cells[current_position]
-				var dmap: DMap = map_cell.dmap
+				var map_cell: OvermapGrid.map_cell = mygrid.cells[current_position]
+				var rmap: RMap = map_cell.rmap
 				var myrotation: int = map_cell.rotation
-				tile_instance.set_texture(dmap.sprite)
+				tile_instance.set_texture(rmap.sprite)
 				# HACK: Second argument is the pivot offset. The automatic calculations for this are
 				# failing for some reason, so we put in half the minumum size of 32 in manually
 				tile_instance.set_texture_rotation(myrotation, Vector2(16, 16))

--- a/Scenes/ContentManager/OtherTools/Scripts/overmap_grid_visualization.gd
+++ b/Scenes/ContentManager/OtherTools/Scripts/overmap_grid_visualization.gd
@@ -5,6 +5,10 @@ extends Control
 
 
 func _on_generate_button_button_up() -> void:
+	# Rebuild all runtime data before generating the grid
+	# This ensures the visualization uses the latest mod information
+	# If reconstruction fails, the error will be printed in debug output
+	Runtimedata.reconstruct()
 	Helper.free_all_children(visual_grid)
 	generate_grid()
 


### PR DESCRIPTION
## Summary
- ensure runtime data reloads when generating the overmap grid

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_687b852d4a048325872e4a86c9027d98