### PR TITLE
Fix doc typo, standardize variable names

### DIFF
--- a/.project-management/current-prd/tasks-doc-style-consistency.md
+++ b/.project-management/current-prd/tasks-doc-style-consistency.md
@@ -330,10 +330,10 @@ Documentation & Style Consistency (Goal #10)
 
 ### Existing Files Modified
 - `Documentation/Game_development/Working_with_codex.md` - Fix typo "Dimenionfall".
-- `Scripts/ItemMeleeEditor.gd` - Rename form variables to snake_case.
-- `Scripts/ItemAmmoEditor.gd` - Rename form variables to snake_case.
-- `Scripts/ItemMagazineEditor.gd` - Rename form variables to snake_case.
-- `Scripts/ItemRangedEditor.gd` - Rename form variables to snake_case.
+- `Scripts/ItemMeleeEditor.gd` - Rename form variables to snake_case and normalize comments.
+- `Scripts/ItemAmmoEditor.gd` - Rename form variables to snake_case and normalize comments.
+- `Scripts/ItemMagazineEditor.gd` - Rename form variables to snake_case and normalize comments.
+- `Scripts/ItemRangedEditor.gd` - Rename form variables to snake_case and normalize comments.
 
 ### Files To Remove
 - None
@@ -342,8 +342,8 @@ Documentation & Style Consistency (Goal #10)
 - Unit tests should typically be placed in `/Tests/Unit/`.
 
 ## Tasks
-- [ ] 1.0 Correct Documentation Typos
-- [ ] 3.0 Standardize Editor Script Variable Names
-- [ ] 5.0 Review and Normalize Script Comments
+- [x] 1.0 Correct Documentation Typos
+- [x] 3.0 Standardize Editor Script Variable Names
+- [x] 5.0 Review and Normalize Script Comments
 
 *End of document*

--- a/Documentation/Game_development/Working_with_codex.md
+++ b/Documentation/Game_development/Working_with_codex.md
@@ -10,7 +10,7 @@ You can use this guide if you have access to https://chatgpt.com/codex
 
 ## First time setup
 1. In codex, go to https://chatgpt.com/codex/settings/general and remove any custom instructions you may have previously used.
-2. Go to https://chatgpt.com/codex/settings/environments, select or create your github-connected fork of the Dimenionfall game.
+2. Go to https://chatgpt.com/codex/settings/environments, select or create your github-connected fork of the Dimensionfall game.
 3. Press Edit -> copy-paste this into the startup script textbox and Save:
 ```
 # 1. Download the latest Godot 4.x Linux 64-bit binary

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemAmmoEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemAmmoEditor.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://coyt00mcucd8n" path="res://Scripts/ItemAmmoEditor.gd" id="1_5v06u"]
 
-[node name="ItemAmmoEditor" type="Control" node_paths=PackedStringArray("DamageNumberBox")]
+[node name="ItemAmmoEditor" type="Control" node_paths=PackedStringArray("damage_number_box")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -10,7 +10,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_5v06u")
-DamageNumberBox = NodePath("Ammo/DamageNumber")
+damage_number_box = NodePath("Ammo/DamageNumber")
 
 [node name="Ammo" type="GridContainer" parent="."]
 layout_mode = 0

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMagazineEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMagazineEditor.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://6c1lyc6bwknh" path="res://Scripts/ItemMagazineEditor.gd" id="1_cgvqr"]
 
-[node name="ItemMagazineEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "MaxAmmoNumberBox", "CurrentAmmoNumberBox")]
+[node name="ItemMagazineEditor" type="Control" node_paths=PackedStringArray("used_ammo_text_edit", "max_ammo_number_box", "current_ammo_number_box")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -10,9 +10,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_cgvqr")
-UsedAmmoTextEdit = NodePath("Magazine/UsedAmmoTextEdit")
-MaxAmmoNumberBox = NodePath("Magazine/MaxAmmoNumber")
-CurrentAmmoNumberBox = NodePath("Magazine/CurrentAmmoNumber")
+used_ammo_text_edit = NodePath("Magazine/UsedAmmoTextEdit")
+max_ammo_number_box = NodePath("Magazine/MaxAmmoNumber")
+current_ammo_number_box = NodePath("Magazine/CurrentAmmoNumber")
 
 [node name="Magazine" type="GridContainer" parent="."]
 layout_mode = 1

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn
@@ -4,7 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_etmci"]
 [ext_resource type="PackedScene" uid="uid://dmlbg7nolncnh" path="res://Scenes/ContentManager/Custom_Widgets/DropEntityTextEdit.tscn" id="3_kgnfh"]
 
-[node name="ItemMeleeEditor" type="Control" node_paths=PackedStringArray("DamageSpinBox", "ReachSpinBox", "UsedSkillTextEdit", "skill_xp_spin_box", "damage_stat_text_edit", "accuracy_stat_text_edit")]
+[node name="ItemMeleeEditor" type="Control" node_paths=PackedStringArray("damage_spin_box", "reach_spin_box", "used_skill_text_edit", "skill_xp_spin_box", "damage_stat_text_edit", "accuracy_stat_text_edit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -12,9 +12,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_pg18d")
-DamageSpinBox = NodePath("Melee/DamageSpinbox")
-ReachSpinBox = NodePath("Melee/ReachSpinbox")
-UsedSkillTextEdit = NodePath("Melee/UsedSkillHBoxContainer/UsedSkillTextEdit")
+damage_spin_box = NodePath("Melee/DamageSpinbox")
+reach_spin_box = NodePath("Melee/ReachSpinbox")
+used_skill_text_edit = NodePath("Melee/UsedSkillHBoxContainer/UsedSkillTextEdit")
 skill_xp_spin_box = NodePath("Melee/UsedSkillHBoxContainer/SkillXPSpinBox")
 damage_stat_text_edit = NodePath("Melee/DamageStatTextEdit")
 accuracy_stat_text_edit = NodePath("Melee/AccuracyStatTextEdit")

--- a/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
+++ b/Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://cibcfcysyj15" path="res://Scripts/ItemRangedEditor.gd" id="1_my1v7"]
 [ext_resource type="PackedScene" uid="uid://dsax7il2yggw8" path="res://Scenes/ContentManager/Custom_Widgets/DropEnabledTextEdit.tscn" id="2_crphu"]
 
-[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("UsedAmmoTextEdit", "UsedMagazineGridContainer", "RangeNumberBox", "SpreadNumberBox", "SwayNumberBox", "RecoilNumberBox", "UsedSkillTextEdit", "skill_xp_spin_box", "ReloadSpeedNumberBox", "FiringSpeedNumberBox", "accuracy_stat_text_edit")]
+[node name="ItemRangedEditor" type="Control" node_paths=PackedStringArray("used_ammo_text_edit", "used_magazine_grid_container", "range_number_box", "spread_number_box", "sway_number_box", "recoil_number_box", "used_skill_text_edit", "skill_xp_spin_box", "reload_speed_number_box", "firing_speed_number_box", "accuracy_stat_text_edit")]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -11,16 +11,16 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_my1v7")
-UsedAmmoTextEdit = NodePath("Ranged/UsedAmmoTextEdit")
-UsedMagazineGridContainer = NodePath("Ranged/UsedMagazineGridContainer")
-RangeNumberBox = NodePath("Ranged/RangeNumber")
-SpreadNumberBox = NodePath("Ranged/SpreadNumber")
-SwayNumberBox = NodePath("Ranged/SwayNumber")
-RecoilNumberBox = NodePath("Ranged/RecoilNumber")
-UsedSkillTextEdit = NodePath("Ranged/SkillHBoxContainer/UsedSkillTextEdit")
+used_ammo_text_edit = NodePath("Ranged/UsedAmmoTextEdit")
+used_magazine_grid_container = NodePath("Ranged/UsedMagazineGridContainer")
+range_number_box = NodePath("Ranged/RangeNumber")
+spread_number_box = NodePath("Ranged/SpreadNumber")
+sway_number_box = NodePath("Ranged/SwayNumber")
+recoil_number_box = NodePath("Ranged/RecoilNumber")
+used_skill_text_edit = NodePath("Ranged/SkillHBoxContainer/UsedSkillTextEdit")
 skill_xp_spin_box = NodePath("Ranged/SkillHBoxContainer/SkillXPSpinBox")
-ReloadSpeedNumberBox = NodePath("Ranged/ReloadSpeedNumber")
-FiringSpeedNumberBox = NodePath("Ranged/FiringSpeedNumber")
+reload_speed_number_box = NodePath("Ranged/ReloadSpeedNumber")
+firing_speed_number_box = NodePath("Ranged/FiringSpeedNumber")
 accuracy_stat_text_edit = NodePath("Ranged/AccuracyStatTextEdit")
 
 [node name="Ranged" type="GridContainer" parent="."]

--- a/Scripts/ItemAmmoEditor.gd
+++ b/Scripts/ItemAmmoEditor.gd
@@ -1,12 +1,10 @@
 extends Control
 
-# This scene is intended to be used inside the item editor
-# It is supposed to edit exactly one type of ammo
+# This scene is intended to be used inside the item editor.
+# It is supposed to edit exactly one type of ammo.
 
-
-# Form elements
-@export var DamageNumberBox: SpinBox = null
-
+# Form elements.
+@export var damage_number_box: SpinBox = null
 
 var ditem: DItem = null:
 	set(value):
@@ -15,11 +13,13 @@ var ditem: DItem = null:
 		ditem = value
 		load_properties()
 
+
 func save_properties() -> void:
-	ditem.ammo.damage = int(DamageNumberBox.value)
+	ditem.ammo.damage = int(damage_number_box.value)
+
 
 func load_properties() -> void:
 	if not ditem.ammo:
 		print_debug("ditem.ammo is null, skipping property loading.")
 		return
-	DamageNumberBox.value = ditem.ammo.damage
+	damage_number_box.value = ditem.ammo.damage

--- a/Scripts/ItemMagazineEditor.gd
+++ b/Scripts/ItemMagazineEditor.gd
@@ -1,14 +1,12 @@
 extends Control
 
-# This scene is intended to be used inside the item editor
-# It is supposed to edit exactly one magazine
+# This scene is intended to be used inside the item editor.
+# It is supposed to edit exactly one magazine.
 
-
-# Form elements
-@export var UsedAmmoTextEdit: TextEdit = null
-@export var MaxAmmoNumberBox: SpinBox = null
-@export var CurrentAmmoNumberBox: SpinBox = null
-
+# Form elements.
+@export var used_ammo_text_edit: TextEdit = null
+@export var max_ammo_number_box: SpinBox = null
+@export var current_ammo_number_box: SpinBox = null
 
 var ditem: DItem = null:
 	set(value):
@@ -17,15 +15,17 @@ var ditem: DItem = null:
 		ditem = value
 		load_properties()
 
+
 func save_properties() -> void:
-	ditem.magazine.used_ammo = UsedAmmoTextEdit.text
-	ditem.magazine.max_ammo = int(MaxAmmoNumberBox.value)
-	ditem.magazine.current_ammo = int(CurrentAmmoNumberBox.value)
+	ditem.magazine.used_ammo = used_ammo_text_edit.text
+	ditem.magazine.max_ammo = int(max_ammo_number_box.value)
+	ditem.magazine.current_ammo = int(current_ammo_number_box.value)
+
 
 func load_properties() -> void:
 	if not ditem.magazine:
 		print_debug("ditem.magazine is null, skipping property loading.")
 		return
-	UsedAmmoTextEdit.text = ditem.magazine.used_ammo
-	MaxAmmoNumberBox.value = ditem.magazine.max_ammo
-	CurrentAmmoNumberBox.value = ditem.magazine.current_ammo
+	used_ammo_text_edit.text = ditem.magazine.used_ammo
+	max_ammo_number_box.value = ditem.magazine.max_ammo
+	current_ammo_number_box.value = ditem.magazine.current_ammo

--- a/Scripts/ItemMeleeEditor.gd
+++ b/Scripts/ItemMeleeEditor.gd
@@ -1,12 +1,12 @@
 extends Control
 
-# This scene is intended to be used inside the item editor
-# It is supposed to edit exactly one type of melee weapon
+# This scene is intended to be used inside the item editor.
+# It is supposed to edit exactly one type of melee weapon.
 
-# Form elements
-@export var DamageSpinBox: SpinBox = null
-@export var ReachSpinBox: SpinBox = null
-@export var UsedSkillTextEdit: HBoxContainer = null
+# Form elements.
+@export var damage_spin_box: SpinBox = null
+@export var reach_spin_box: SpinBox = null
+@export var used_skill_text_edit: HBoxContainer = null
 @export var skill_xp_spin_box: SpinBox = null
 @export var damage_stat_text_edit: HBoxContainer = null
 @export var accuracy_stat_text_edit: HBoxContainer = null
@@ -17,11 +17,13 @@ var ditem: DItem = null:
 			return
 		ditem = value
 		load_properties()
-	
+
+
 func _ready():
 	set_drop_functions()
 	damage_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
 	accuracy_stat_text_edit.content_types = [DMod.ContentType.STATS] as Array[DMod.ContentType]
+
 
 # Load the properties from the ditem.melee and update the UI elements
 func load_properties() -> void:
@@ -29,37 +31,37 @@ func load_properties() -> void:
 		print_debug("ditem.melee is null, skipping property loading.")
 		return
 	if ditem.melee.damage:
-		DamageSpinBox.value = ditem.melee.damage
+		damage_spin_box.value = ditem.melee.damage
 	if ditem.melee.reach:
-		ReachSpinBox.value = ditem.melee.reach
+		reach_spin_box.value = ditem.melee.reach
 
 		if ditem.melee.used_skill.has("skill_id"):
-				UsedSkillTextEdit.set_text(ditem.melee.used_skill["skill_id"])
+			used_skill_text_edit.set_text(ditem.melee.used_skill["skill_id"])
 		if ditem.melee.used_skill.has("xp"):
-				skill_xp_spin_box.value = ditem.melee.used_skill["xp"]
+			skill_xp_spin_box.value = ditem.melee.used_skill["xp"]
 	if ditem.melee.damage_stat != "":
 		damage_stat_text_edit.set_text(ditem.melee.damage_stat)
 	if ditem.melee.accuracy_stat != "":
 		accuracy_stat_text_edit.set_text(ditem.melee.accuracy_stat)
 
+
 # Save the properties from the UI elements back to ditem.melee
 func save_properties() -> void:
-	ditem.melee.damage = int(DamageSpinBox.value)
-	ditem.melee.reach = int(ReachSpinBox.value)
+	ditem.melee.damage = int(damage_spin_box.value)
+	ditem.melee.reach = int(reach_spin_box.value)
 	ditem.melee.damage_stat = damage_stat_text_edit.get_text()
 	ditem.melee.accuracy_stat = accuracy_stat_text_edit.get_text()
 
-	if UsedSkillTextEdit.get_text() != "":
+	if used_skill_text_edit.get_text() != "":
 		ditem.melee.used_skill = {
-			"skill_id": UsedSkillTextEdit.get_text(),
-			"xp": skill_xp_spin_box.value
+			"skill_id": used_skill_text_edit.get_text(), "xp": skill_xp_spin_box.value
 		}
 	else:
 		ditem.melee.used_skill.clear()
 
 
-# Called when the user has successfully dropped data onto the skillTextEdit
-# We have to check the dropped_data for the id property
+# Called when the user successfully drops data onto the skillTextEdit.
+# Checks the `dropped_data` dictionary for the `id` property.
 func skill_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
@@ -76,7 +78,7 @@ func can_skill_drop(dropped_data: Dictionary):
 	# Check if the data dictionary has the 'id' property
 	if not dropped_data or not dropped_data.has("id"):
 		return false
-	
+
 	# Fetch skill data by ID from the Gamedata to ensure it exists and is valid
 	if not Gamedata.mods.by_id(dropped_data["mod_id"]).skills.has_id(dropped_data["id"]):
 		return false
@@ -84,8 +86,9 @@ func can_skill_drop(dropped_data: Dictionary):
 	# If all checks pass, return true
 	return true
 
-# Set the drop functions on the required skill and skill progression controls
-# This enables them to receive drop data
+
+# Set the drop functions on the required skill and skill progression controls.
+# This enables them to receive drop data.
 func set_drop_functions():
-	UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)
-	UsedSkillTextEdit.can_drop_function = can_skill_drop
+	used_skill_text_edit.drop_function = skill_drop.bind(used_skill_text_edit)
+	used_skill_text_edit.can_drop_function = can_skill_drop

--- a/Scripts/ItemRangedEditor.gd
+++ b/Scripts/ItemRangedEditor.gd
@@ -1,19 +1,19 @@
 extends Control
 
-# This scene is intended to be used inside the item editor
-# It is supposed to edit exactly one ranged weapon
+# This scene is intended to be used inside the item editor.
+# It is supposed to edit exactly one ranged weapon.
 
-# Ranged form elements
-@export var UsedAmmoTextEdit: TextEdit = null
-@export var UsedMagazineGridContainer: GridContainer = null  # Holds magazine entries in a grid
-@export var RangeNumberBox: SpinBox = null
-@export var SpreadNumberBox: SpinBox = null
-@export var SwayNumberBox: SpinBox = null
-@export var RecoilNumberBox: SpinBox = null
-@export var UsedSkillTextEdit: HBoxContainer = null
+# Ranged form elements.
+@export var used_ammo_text_edit: TextEdit = null
+@export var used_magazine_grid_container: GridContainer = null  # Holds magazine entries in a grid.
+@export var range_number_box: SpinBox = null
+@export var spread_number_box: SpinBox = null
+@export var sway_number_box: SpinBox = null
+@export var recoil_number_box: SpinBox = null
+@export var used_skill_text_edit: HBoxContainer = null
 @export var skill_xp_spin_box: SpinBox = null
-@export var ReloadSpeedNumberBox: SpinBox = null
-@export var FiringSpeedNumberBox: SpinBox = null
+@export var reload_speed_number_box: SpinBox = null
+@export var firing_speed_number_box: SpinBox = null
 @export var accuracy_stat_text_edit: HBoxContainer = null
 
 var ditem: DItem = null:
@@ -26,12 +26,16 @@ var ditem: DItem = null:
 
 func _ready():
 	set_drop_functions()
-	if UsedMagazineGridContainer:
-		UsedMagazineGridContainer.set_drag_forwarding(Callable(), _can_magazine_drop, _magazine_drop)
+	if used_magazine_grid_container:
+		used_magazine_grid_container.set_drag_forwarding(
+			Callable(), _can_magazine_drop, _magazine_drop
+		)
 
 
 func _add_magazine_entry(magazine_id: String) -> void:
-	var item_sprite: Texture = Gamedata.mods.get_content_by_id(DMod.ContentType.ITEMS, magazine_id).sprite
+	var item_sprite: Texture = (
+		Gamedata.mods.get_content_by_id(DMod.ContentType.ITEMS, magazine_id).sprite
+	)
 	var icon = TextureRect.new()
 	icon.texture = item_sprite
 	icon.custom_minimum_size = Vector2(32, 32)
@@ -41,38 +45,39 @@ func _add_magazine_entry(magazine_id: String) -> void:
 
 	var delete_button = Button.new()
 	delete_button.text = "X"
-	delete_button.button_up.connect(_on_delete_magazine_button_pressed.bind([icon, label, delete_button]))
+	delete_button.button_up.connect(
+		_on_delete_magazine_button_pressed.bind([icon, label, delete_button])
+	)
 
-	UsedMagazineGridContainer.add_child(icon)
-	UsedMagazineGridContainer.add_child(label)
-	UsedMagazineGridContainer.add_child(delete_button)
+	used_magazine_grid_container.add_child(icon)
+	used_magazine_grid_container.add_child(label)
+	used_magazine_grid_container.add_child(delete_button)
 
 
-# Returns the properties of the ranged tab in the item editor
+# Returns the properties of the ranged tab in the item editor.
 func save_properties() -> void:
 	var selected_magazines: Array[String] = []
-	var num_columns: int = UsedMagazineGridContainer.columns
-	var children := UsedMagazineGridContainer.get_children()
+	var num_columns: int = used_magazine_grid_container.columns
+	var children := used_magazine_grid_container.get_children()
 	for i in range(0, children.size(), num_columns):
 		var label := children[i + 1] as Label
 		if label:
 			selected_magazines.append(label.text)
-	
-	ditem.ranged.used_ammo = UsedAmmoTextEdit.text
+
+	ditem.ranged.used_ammo = used_ammo_text_edit.text
 	ditem.ranged.used_magazine = ",".join(selected_magazines)  # Join the selected magazines by commas
-	ditem.ranged.firing_range = int(RangeNumberBox.value)
-	ditem.ranged.spread = int(SpreadNumberBox.value)
-	ditem.ranged.sway = int(SwayNumberBox.value)
-	ditem.ranged.recoil = int(RecoilNumberBox.value)
-	ditem.ranged.reload_speed = ReloadSpeedNumberBox.value
-	ditem.ranged.firing_speed = FiringSpeedNumberBox.value
+	ditem.ranged.firing_range = int(range_number_box.value)
+	ditem.ranged.spread = int(spread_number_box.value)
+	ditem.ranged.sway = int(sway_number_box.value)
+	ditem.ranged.recoil = int(recoil_number_box.value)
+	ditem.ranged.reload_speed = reload_speed_number_box.value
+	ditem.ranged.firing_speed = firing_speed_number_box.value
 	ditem.ranged.accuracy_stat = accuracy_stat_text_edit.get_text()
-	
-	# Only include used_skill if UsedSkillTextEdit has a value
-	if UsedSkillTextEdit.get_text() != "":
+
+# Only include used_skill if used_skill_text_edit has a value.
+	if used_skill_text_edit.get_text() != "":
 		ditem.ranged.used_skill = {
-			"skill_id": UsedSkillTextEdit.get_text(),
-			"xp": skill_xp_spin_box.value
+			"skill_id": used_skill_text_edit.get_text(), "xp": skill_xp_spin_box.value
 		}
 	else:
 		ditem.ranged.used_skill.clear()
@@ -83,29 +88,29 @@ func load_properties() -> void:
 		print_debug("ditem.ranged is null, skipping property loading.")
 		return
 	if ditem.ranged.used_ammo != "":
-		UsedAmmoTextEdit.text = ditem.ranged.used_ammo
-		if UsedMagazineGridContainer:
-			Helper.free_all_children(UsedMagazineGridContainer)
+		used_ammo_text_edit.text = ditem.ranged.used_ammo
+		if used_magazine_grid_container:
+			Helper.free_all_children(used_magazine_grid_container)
 		if ditem.ranged.used_magazine != "":
 			var used_magazines = ditem.ranged.used_magazine.split(",")
 			for mag_id in used_magazines:
 				_add_magazine_entry(mag_id)
-	RangeNumberBox.value = ditem.ranged.firing_range
-	SpreadNumberBox.value = ditem.ranged.spread
-	SwayNumberBox.value = ditem.ranged.sway
-	RecoilNumberBox.value = ditem.ranged.recoil
-	ReloadSpeedNumberBox.value = ditem.ranged.reload_speed
-	FiringSpeedNumberBox.value = ditem.ranged.firing_speed
+	range_number_box.value = ditem.ranged.firing_range
+	spread_number_box.value = ditem.ranged.spread
+	sway_number_box.value = ditem.ranged.sway
+	recoil_number_box.value = ditem.ranged.recoil
+	reload_speed_number_box.value = ditem.ranged.reload_speed
+	firing_speed_number_box.value = ditem.ranged.firing_speed
 	accuracy_stat_text_edit.set_text(ditem.ranged.accuracy_stat)
-	
+
 	if ditem.ranged.used_skill.has("skill_id"):
-		UsedSkillTextEdit.set_text(ditem.ranged.used_skill["skill_id"])
+		used_skill_text_edit.set_text(ditem.ranged.used_skill["skill_id"])
 	if ditem.ranged.used_skill.has("xp"):
 		skill_xp_spin_box.value = ditem.ranged.used_skill["xp"]
 
 
-# Called when the user has successfully dropped data onto the skillTextEdit
-# We have to check the dropped_data for the id property
+# Called when the user successfully drops data onto the skillTextEdit.
+# Checks the `dropped_data` dictionary for the `id` property.
 func skill_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
 	# dropped_data is a Dictionary that includes an 'id'
 	if dropped_data and "id" in dropped_data:
@@ -122,13 +127,14 @@ func can_skill_drop(dropped_data: Dictionary):
 	# Check if the data dictionary has the 'id' property
 	if not dropped_data or not dropped_data.has("id"):
 		return false
-	
+
 	# Fetch skill data by ID from the Gamedata to ensure it exists and is valid
 	if not Gamedata.mods.by_id(dropped_data["mod_id"]).skills.has_id(dropped_data["id"]):
 		return false
 
 	# If all checks pass, return true
 	return true
+
 
 func stat_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void:
 	if dropped_data and dropped_data.has("id"):
@@ -139,6 +145,7 @@ func stat_drop(dropped_data: Dictionary, texteditcontrol: HBoxContainer) -> void
 		texteditcontrol.set_text(stat_id)
 	else:
 		print_debug("Dropped data does not contain an 'id' key.")
+
 
 func can_stat_drop(dropped_data: Dictionary):
 	if not dropped_data or not dropped_data.has("id"):
@@ -157,7 +164,7 @@ func _can_magazine_drop(_newpos: Vector2, data: Dictionary) -> bool:
 	if ditem.magazine == null:
 		return false
 
-	for child in UsedMagazineGridContainer.get_children():
+	for child in used_magazine_grid_container.get_children():
 		if child is Label and child.text == data["id"]:
 			return false
 	return true
@@ -174,10 +181,10 @@ func _on_delete_magazine_button_pressed(controls: Array) -> void:
 		c.queue_free()
 
 
-# Set the drop functions on the required skill and skill progression controls
-# This enables them to receive drop data
+# Set the drop functions on the required skill and skill progression controls.
+# This enables them to receive drop data.
 func set_drop_functions():
-	UsedSkillTextEdit.drop_function = skill_drop.bind(UsedSkillTextEdit)
-	UsedSkillTextEdit.can_drop_function = can_skill_drop
+	used_skill_text_edit.drop_function = skill_drop.bind(used_skill_text_edit)
+	used_skill_text_edit.can_drop_function = can_skill_drop
 	accuracy_stat_text_edit.drop_function = stat_drop.bind(accuracy_stat_text_edit)
 	accuracy_stat_text_edit.can_drop_function = can_stat_drop

--- a/Tests/Unit/test_item_melee_editor.gd
+++ b/Tests/Unit/test_item_melee_editor.gd
@@ -1,44 +1,56 @@
 extends GutTest
 
-var melee_editor_scene: PackedScene = preload("res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn")
+var melee_editor_scene: PackedScene = preload(
+	"res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemMeleeEditor.tscn"
+)
 var editor_instance: Control = null
 var my_ditem: DItem = null
+
 
 func before_all():
 	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
 	Runtimedata.reconstruct(custom_mods)
 	await get_tree().process_frame
 
+
 func before_each():
-	my_ditem = DItem.new({
-		"id": "test_melee_item",
-		"Melee": {
-			"damage": 5,
-			"reach": 1,
-			"used_skill": {"skill_id": "bashing", "xp": 1.0},
-			"damage_stat": "strength",
-			"accuracy_stat": "dexterity"
-		}
-	}, null)
+	my_ditem = DItem.new(
+		{
+			"id": "test_melee_item",
+			"Melee":
+			{
+				"damage": 5,
+				"reach": 1,
+				"used_skill": {"skill_id": "bashing", "xp": 1.0},
+				"damage_stat": "strength",
+				"accuracy_stat": "dexterity"
+			}
+		},
+		null
+	)
 	editor_instance = melee_editor_scene.instantiate()
 	get_tree().root.add_child(editor_instance)
 	await get_tree().process_frame
 	editor_instance.ditem = my_ditem
 
+
 func after_each():
 	if editor_instance:
 		editor_instance.queue_free()
 
+
 func after_all():
 	Runtimedata.reset()
 
+
 func test_editor_loads_melee_data():
-	assert_eq(editor_instance.DamageSpinBox.value, 5)
-	assert_eq(editor_instance.ReachSpinBox.value, 1)
-	assert_eq(editor_instance.UsedSkillTextEdit.get_text(), "bashing")
+	assert_eq(editor_instance.damage_spin_box.value, 5)
+	assert_eq(editor_instance.reach_spin_box.value, 1)
+	assert_eq(editor_instance.used_skill_text_edit.get_text(), "bashing")
 	assert_eq(editor_instance.skill_xp_spin_box.value, 1.0)
 	assert_eq(editor_instance.damage_stat_text_edit.get_text(), "strength")
 	assert_eq(editor_instance.accuracy_stat_text_edit.get_text(), "dexterity")
+
 
 func test_drop_damage_stat_and_save():
 	var dropdata: Dictionary = {
@@ -51,6 +63,7 @@ func test_drop_damage_stat_and_save():
 	assert_eq(editor_instance.damage_stat_text_edit.get_text(), "dexterity")
 	editor_instance.save_properties()
 	assert_eq(my_ditem.melee.damage_stat, "dexterity")
+
 
 func test_drop_accuracy_stat_and_save():
 	var dropdata: Dictionary = {

--- a/Tests/Unit/test_item_ranged_editor.gd
+++ b/Tests/Unit/test_item_ranged_editor.gd
@@ -1,39 +1,50 @@
 extends GutTest
 
-var ranged_editor_scene: PackedScene = preload("res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn")
+var ranged_editor_scene: PackedScene = preload(
+	"res://Scenes/ContentManager/Custom_Editors/ItemEditor/ItemRangedEditor.tscn"
+)
 var editor_instance: Control = null
 var my_ditem: DItem = null
+
 
 func before_all():
 	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
 	Runtimedata.reconstruct(custom_mods)
 	await get_tree().process_frame
 
+
 func before_each():
-	my_ditem = DItem.new({
-		"id": "test_ranged_item",
-		"Ranged": {
-			"firing_speed": 0.5,
-			"range": 500,
-			"recoil": 5,
-			"reload_speed": 1.0,
-			"spread": 2,
-			"sway": 1,
-			"used_ammo": "9mm",
-			"used_magazine": ""
-		}
-	}, null)
+	my_ditem = DItem.new(
+		{
+			"id": "test_ranged_item",
+			"Ranged":
+			{
+				"firing_speed": 0.5,
+				"range": 500,
+				"recoil": 5,
+				"reload_speed": 1.0,
+				"spread": 2,
+				"sway": 1,
+				"used_ammo": "9mm",
+				"used_magazine": ""
+			}
+		},
+		null
+	)
 	editor_instance = ranged_editor_scene.instantiate()
 	get_tree().root.add_child(editor_instance)
 	await get_tree().process_frame
 	editor_instance.ditem = my_ditem
 
+
 func after_each():
 	if editor_instance:
 		editor_instance.queue_free()
 
+
 func after_all():
 	Runtimedata.reset()
+
 
 func test_valid_magazine_drop() -> void:
 	var data := {
@@ -44,10 +55,11 @@ func test_valid_magazine_drop() -> void:
 	}
 	editor_instance._magazine_drop(Vector2.ZERO, data)
 	var found := false
-	for child in editor_instance.UsedMagazineGridContainer.get_children():
+	for child in editor_instance.used_magazine_grid_container.get_children():
 		if child is Label and child.text == "generic_test_pistol_magazine":
 			found = true
 	assert_true(found)
+
 
 func test_invalid_magazine_drop() -> void:
 	var data := {
@@ -58,10 +70,11 @@ func test_invalid_magazine_drop() -> void:
 	}
 	editor_instance._magazine_drop(Vector2.ZERO, data)
 	var found := false
-	for child in editor_instance.UsedMagazineGridContainer.get_children():
+	for child in editor_instance.used_magazine_grid_container.get_children():
 		if child is Label and child.text == "generic_test_item":
 			found = true
 	assert_false(found)
+
 
 func test_save_and_load_preserves_magazines() -> void:
 	var data := {
@@ -73,10 +86,10 @@ func test_save_and_load_preserves_magazines() -> void:
 	editor_instance._magazine_drop(Vector2.ZERO, data)
 	editor_instance.save_properties()
 	assert_eq(my_ditem.ranged.used_magazine, "generic_test_pistol_magazine")
-	Helper.free_all_children(editor_instance.UsedMagazineGridContainer)
+	Helper.free_all_children(editor_instance.used_magazine_grid_container)
 	editor_instance.load_properties()
 	var found := false
-	for child in editor_instance.UsedMagazineGridContainer.get_children():
+	for child in editor_instance.used_magazine_grid_container.get_children():
 		if child is Label and child.text == "generic_test_pistol_magazine":
 			found = true
 	assert_true(found)


### PR DESCRIPTION
## Summary
- fix documentation typo in codex guide
- standardize variable names in item editor scripts and update scenes
- adjust tests for new variable names
- normalize comments in item editor scripts
- update task list

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_687cb3bf2dd88325aae5241ca659fd7d