### PR TITLE
Add npc tile button

### DIFF
--- a/.project-management/current-prd/tasks-prd-npc_tile.md
+++ b/.project-management/current-prd/tasks-prd-npc_tile.md
@@ -59,10 +59,10 @@
 - Data stored per tile like other entities; not tracked in references.
 
 ## Tasks
-- [ ] 1.0 Add npc_tile button to brush composer scene and connect signal.
-  - [ ] 1.1 Create a new button node next to the existing null_tile button.
-  - [ ] 1.2 Assign `res://Scenes/ContentManager/Mapeditor/Images/nulltile_32.png` as its icon.
-  - [ ] 1.3 Connect the button's `button_up` signal to mapeditor_brushcomposer.gd.
+- [x] 1.0 Add npc_tile button to brush composer scene and connect signal.
+  - [x] 1.1 Create a new button node next to the existing null_tile button.
+  - [x] 1.2 Assign `res://Scenes/ContentManager/Mapeditor/Images/nulltile_32.png` as its icon.
+  - [x] 1.3 Connect the button's `button_up` signal to mapeditor_brushcomposer.gd.
 - [ ] 2.0 Extend mapeditor_brushcomposer.gd with `_on_npc_tile_button_up` and property handling.
   - [ ] 2.1 Add a boolean property tracking npc_tile brush selection.
   - [ ] 2.2 Implement `_on_npc_tile_button_up()` to toggle this property and update UI state.

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -469,3 +469,8 @@ func _on_null_tile_button_up():
 		"entityType": "tile"
 	}
 	add_tilebrush_to_container_with_properties(null_tile_properties)
+
+
+# Function to be called when the npc tile button is pressed
+func _on_npc_tile_button_up():
+	print_debug("This function needs further implementation")

--- a/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
@@ -9,13 +9,14 @@
 [ext_resource type="Texture2D" uid="uid://is8cme122co7" path="res://Scenes/ContentManager/Mapeditor/Images/nulltile_32.png" id="6_m76ty"]
 [ext_resource type="PackedScene" uid="uid://mnwn367pi4op" path="res://Scenes/ContentManager/Mapeditor/Map_Editor_Areas_Popup.tscn" id="7_b3k8u"]
 
-[node name="CustomBrushVBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("brush_container", "rotation_button", "areas_option_button", "area_editor")]
+[node name="CustomBrushVBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("brush_container", "rotation_button", "areas_option_button", "area_editor", "npc_tile_button")]
 script = ExtResource("1_bl6cv")
 brush_container = NodePath("CurrentBrushScrolling_Flow_Container")
 tileBrush = ExtResource("2_epuda")
 rotation_button = NodePath("CustomBrushToolsHBoxContainer/RotationCheckbox")
 areas_option_button = NodePath("CustomBrushToolsHBoxContainer/AreasOptionButton")
 area_editor = NodePath("Area_editor")
+npc_tile_button = NodePath("CustomBrushToolsHBoxContainer/NpcTileTextureButton")
 
 [node name="CustomBrushToolsHBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
@@ -54,6 +55,13 @@ size_flags_horizontal = 4
 texture_normal = ExtResource("6_m76ty")
 stretch_mode = 3
 
+[node name="NpcTileTextureButton" type="TextureButton" parent="CustomBrushToolsHBoxContainer"]
+custom_minimum_size = Vector2(32, 32)
+layout_mode = 2
+size_flags_horizontal = 4
+texture_normal = ExtResource("6_m76ty")
+stretch_mode = 3
+
 [node name="CurrentBrushScrolling_Flow_Container" parent="." instance=ExtResource("1_ump07")]
 layout_mode = 2
 tooltip_text = "This is the brush composer. It allows you to create a custom brush to paint for your purposes. To add a tile 
@@ -72,4 +80,5 @@ visible = false
 [connection signal="item_selected" from="CustomBrushToolsHBoxContainer/AreasOptionButton" to="." method="_on_areas_option_button_item_selected"]
 [connection signal="button_up" from="CustomBrushToolsHBoxContainer/MapAreaSettingsButton" to="." method="_on_map_area_settings_button_button_up"]
 [connection signal="button_up" from="CustomBrushToolsHBoxContainer/NullTileTextureButton" to="." method="_on_null_tile_button_up"]
+[connection signal="button_up" from="CustomBrushToolsHBoxContainer/NpcTileTextureButton" to="." method="_on_npc_tile_button_up"]
 [connection signal="area_selected_ok" from="Area_editor" to="." method="_on_area_editor_area_selected_ok"]

--- a/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
+++ b/Scenes/ContentManager/Mapeditor/mapeditor_brushcomposer.tscn
@@ -9,14 +9,13 @@
 [ext_resource type="Texture2D" uid="uid://is8cme122co7" path="res://Scenes/ContentManager/Mapeditor/Images/nulltile_32.png" id="6_m76ty"]
 [ext_resource type="PackedScene" uid="uid://mnwn367pi4op" path="res://Scenes/ContentManager/Mapeditor/Map_Editor_Areas_Popup.tscn" id="7_b3k8u"]
 
-[node name="CustomBrushVBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("brush_container", "rotation_button", "areas_option_button", "area_editor", "npc_tile_button")]
+[node name="CustomBrushVBoxContainer" type="VBoxContainer" node_paths=PackedStringArray("brush_container", "rotation_button", "areas_option_button", "area_editor")]
 script = ExtResource("1_bl6cv")
 brush_container = NodePath("CurrentBrushScrolling_Flow_Container")
 tileBrush = ExtResource("2_epuda")
 rotation_button = NodePath("CustomBrushToolsHBoxContainer/RotationCheckbox")
 areas_option_button = NodePath("CustomBrushToolsHBoxContainer/AreasOptionButton")
 area_editor = NodePath("Area_editor")
-npc_tile_button = NodePath("CustomBrushToolsHBoxContainer/NpcTileTextureButton")
 
 [node name="CustomBrushToolsHBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 2
@@ -37,8 +36,8 @@ Select an area to edit. To add a new area, put the option to \"None\" and press 
 toolbar. A new area will be created. You only need this for randomization during map generation. To remove an area, 
 press the area settings button and delete the area from there. To remove tiles from an area, enable the area paint 
 button from the toolbar and enable the erase button in the toolbar and erase the area from the tiles on the map."
-item_count = 1
 selected = 0
+item_count = 1
 popup/item_0/text = "None"
 popup/item_0/id = 0
 


### PR DESCRIPTION
## Summary
- add npc_tile button to the brush composer UI
- update tasks to mark npc tile UI work complete

## Testing
- `godot --headless --import` *(fails: Connection to remote host failed)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_687e97a7d9ec832596445774a7405a70