### PR TITLE
Double mob counts

### DIFF
--- a/Mods/Dimensionfall/Maps/Generichouse.json
+++ b/Mods/Dimensionfall/Maps/Generichouse.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/Generichouse_00.json
+++ b/Mods/Dimensionfall/Maps/Generichouse_00.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/abandoned_building.json
+++ b/Mods/Dimensionfall/Maps/abandoned_building.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/factory_hall.json
+++ b/Mods/Dimensionfall/Maps/factory_hall.json
@@ -138,7 +138,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "security_robots",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_corner.json
+++ b/Mods/Dimensionfall/Maps/generichouse_corner.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_cross.json
+++ b/Mods/Dimensionfall/Maps/generichouse_cross.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_end.json
+++ b/Mods/Dimensionfall/Maps/generichouse_end.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/generichouse_t.json
+++ b/Mods/Dimensionfall/Maps/generichouse_t.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/industrial_control_center.json
+++ b/Mods/Dimensionfall/Maps/industrial_control_center.json
@@ -69,7 +69,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "security_robots",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/neighborhood_school.json
+++ b/Mods/Dimensionfall/Maps/neighborhood_school.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/office_building_00.json
+++ b/Mods/Dimensionfall/Maps/office_building_00.json
@@ -85,7 +85,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/parking_garage.json
+++ b/Mods/Dimensionfall/Maps/parking_garage.json
@@ -71,7 +71,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/radio_tower.json
+++ b/Mods/Dimensionfall/Maps/radio_tower.json
@@ -154,27 +154,27 @@
 		{
 			"entities": [
 				{
-					"count": 10,
+					"count": 20,
 					"id": "disruptor_drone",
 					"type": "mob"
 				},
 				{
-					"count": 2,
+					"count": 4,
 					"id": "scavenger_skitter",
 					"type": "mob"
 				},
 				{
-					"count": 1,
+					"count": 2,
 					"id": "iron_stalker",
 					"type": "mob"
 				},
 				{
-					"count": 4,
+					"count": 8,
 					"id": "scrapwalker",
 					"type": "mob"
 				},
 				{
-					"count": 3,
+					"count": 6,
 					"id": "rust_sentinel",
 					"type": "mob"
 				}

--- a/Mods/Dimensionfall/Maps/scrap_yard.json
+++ b/Mods/Dimensionfall/Maps/scrap_yard.json
@@ -121,7 +121,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "security_robots",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/store_electronic_clothing.json
+++ b/Mods/Dimensionfall/Maps/store_electronic_clothing.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/subway_station.json
+++ b/Mods/Dimensionfall/Maps/subway_station.json
@@ -104,7 +104,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/two_story_house.json
+++ b/Mods/Dimensionfall/Maps/two_story_house.json
@@ -3,7 +3,7 @@
 		{
 			"entities": [
 				{
-					"count": 24.0,
+					"count": 48.0,
 					"id": "basic_zombies",
 					"type": "mobgroup"
 				}

--- a/Mods/Dimensionfall/Maps/warehouse_storage.json
+++ b/Mods/Dimensionfall/Maps/warehouse_storage.json
@@ -128,7 +128,7 @@
 		{
 			"entities": [
 				{
-					"count": 1,
+					"count": 2,
 					"id": "security_robots",
 					"type": "mobgroup"
 				}


### PR DESCRIPTION
## Summary
- double zombie spawn counts in Dimensionfall map files

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_6883bd609b9483259f21e3007d537998