### PR TITLE
Close PRD with missing chunk tests

### DIFF
--- a/.project-management/closed-prd/tasks-bug-logic-error-identification.md
+++ b/.project-management/closed-prd/tasks-bug-logic-error-identification.md
@@ -64,3 +64,4 @@
   - [x] 1.2 Update related unit tests to cover missing chunk scenarios.
 - [x] 3.0 Safe bullet collision handling
   - [x] 3.1 Ensure `_on_body_shape_entered` and `_on_area_3d_body_shape_entered` skip null bodies and log appropriately.
+- [x] 4.0 Review: Added tests for missing chunk scenarios.

--- a/Tests/Unit/test_map_manager.gd
+++ b/Tests/Unit/test_map_manager.gd
@@ -153,3 +153,43 @@ func test_process_entities_data():
 		assert_does_not_have(result, "mob", "Unexpected mob key")
 		assert_does_not_have(result, "mobgroup", "Unexpected mobgroup key")
 		assert_does_not_have(result, "itemgroup", "Unexpected itemgroup key")
+
+
+# Stub classes for chunk absence tests
+class StubLevelGenerator:
+	extends Node
+
+	func get_chunk(_coord: Vector2):
+		return null
+
+
+class StubPlayer:
+	extends Player
+
+	func get_y_position(_snapped: bool = false) -> float:
+		return 0.0
+
+
+func test_spawn_item_missing_chunk_returns_false():
+	map_manager.level_generator = StubLevelGenerator.new()
+	var player = StubPlayer.new()
+	Helper.overmap_manager.player = player
+	Helper.overmap_manager.player_current_cell = Vector2.ZERO
+	add_child(player)
+	assert_false(
+		map_manager.spawn_item_at_current_player_map("dummy", 1),
+		"Expected false when chunk is missing",
+	)
+	player.queue_free()
+
+
+func test_spawn_mob_missing_chunk_returns_false():
+	map_manager.level_generator = StubLevelGenerator.new()
+	var player = StubPlayer.new()
+	Helper.overmap_manager.player = player
+	add_child(player)
+	assert_false(
+		map_manager.spawn_mob_at_nearby_map("dummy", Vector2.ZERO),
+		"Expected false when chunk is missing",
+	)
+	player.queue_free()


### PR DESCRIPTION
## Summary
- add stub tests for missing chunk scenarios in map_manager
- document follow-up review in tasks
- close PRD by moving tasks to closed folder

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_688639c2edd88325a3d551c03b0b6486