### PR TITLE
Add sub-tasks for code refactor

### DIFF
--- a/.project-management/current-prd/tasks-code-refactor.md
+++ b/.project-management/current-prd/tasks-code-refactor.md
@@ -1,0 +1,98 @@
+## Selected maintenance goal
+- 1 - Code Refactoring & Simplification
+
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Assets
+├── Defaults
+├── Documentation
+├── FeatureList.md
+├── Images
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── Media
+├── Mods
+├── README.md
+├── Scenes
+├── Scripts
+├── Shaders
+├── Sounds
+├── Tests
+├── Textures
+├── day_night.gd
+├── day_night.gd.uid
+├── day_night.tscn
+├── documentation.tscn
+├── entity_manager.gd
+├── entity_manager.gd.uid
+├── export_presets.cfg
+├── front_light.gd
+├── front_light.gd.uid
+├── front_light.tscn
+├── hud.tscn
+├── icon.svg
+├── icon.svg.import
+├── level_generation.tscn
+├── override.cfg
+├── project.godot
+├── scene_selector.tscn
+├── spot_light_3d.tscn
+├── spot_light_3d_2.tscn
+├── test_environment.gd
+├── test_environment.gd.uid
+├── test_environment.tscn
+└── torso.aseprite
+
+13 directories, 33 files
+```
+
+## Relevant Files
+- `Scripts/Chunk.gd` - Complex chunk generation and loading logic.
+- `Scripts/player.gd` - Large player controller with interaction and state logic.
+- `Scripts/item_manager.gd` - Handles equipment and inventory; contains TODO about slot list.
+- `Scripts/hud.gd` - Updates HUD elements and processes input.
+- `Scripts/Helper.gd` - Central utility script managing helpers and signals.
+- `/Tests/Unit/test_chunk.gd` - Tests for chunk functionality.
+- `/Tests/Unit/test_player.gd` - Player behavior tests.
+- `/Tests/Unit/test_item_manager.gd` - Item manager tests.
+
+### Proposed New Files
+*(none at this stage)*
+
+### Existing Files Modified
+*(none yet – to be determined in sub-tasks)*
+
+### Files To Remove
+*(none)*
+
+### Notes
+- Unit tests are in `/Tests/Unit/`.
+
+## Tasks
+- [ ] 1.0 Refactor `Scripts/Chunk.gd` for clarity and modular functions
+  - [ ] 1.1 Break chunk generation into smaller methods
+  - [ ] 1.2 Document generation steps with comments
+  - [ ] 1.3 Remove redundant loops and variables
+  - [ ] 1.4 Extend `/Tests/Unit/test_chunk.gd`
+- [ ] 2.0 Simplify `Scripts/player.gd` interaction and skill logic
+  - [ ] 2.1 Extract interaction logic into a separate function
+  - [ ] 2.2 Consolidate state transitions
+  - [ ] 2.3 Add unit tests for skills
+- [ ] 3.0 Clean up equipment slot management in `Scripts/item_manager.gd`
+  - [ ] 3.1 Replace TODO with defined slot enumeration
+  - [ ] 3.2 Update equip/unequip functions
+  - [ ] 3.3 Add slot validation tests
+- [ ] 4.0 Centralize HUD update logic and signal connections
+  - [ ] 4.1 Move repeated HUD update code into helpers
+  - [ ] 4.2 Connect signals through single handler
+  - [ ] 4.3 Test HUD updates on inventory and health change
+- [ ] 5.0 Review helper utilities and add missing comments
+  - [ ] 5.1 Audit unused helper methods
+  - [ ] 5.2 Add Godot-style docstrings

--- a/.project-management/current-prd/tasks-code-refactor.md
+++ b/.project-management/current-prd/tasks-code-refactor.md
@@ -55,13 +55,7 @@
 
 ## Relevant Files
 - `Scripts/Chunk.gd` - Complex chunk generation and loading logic.
-- `Scripts/player.gd` - Large player controller with interaction and state logic.
-- `Scripts/item_manager.gd` - Handles equipment and inventory; contains TODO about slot list.
-- `Scripts/hud.gd` - Updates HUD elements and processes input.
-- `Scripts/Helper.gd` - Central utility script managing helpers and signals.
 - `/Tests/Unit/test_chunk.gd` - Tests for chunk functionality.
-- `/Tests/Unit/test_player.gd` - Player behavior tests.
-- `/Tests/Unit/test_item_manager.gd` - Item manager tests.
 
 ### Proposed New Files
 *(none at this stage)*
@@ -81,18 +75,3 @@
   - [ ] 1.2 Document generation steps with comments
   - [ ] 1.3 Remove redundant loops and variables
   - [ ] 1.4 Extend `/Tests/Unit/test_chunk.gd`
-- [ ] 2.0 Simplify `Scripts/player.gd` interaction and skill logic
-  - [ ] 2.1 Extract interaction logic into a separate function
-  - [ ] 2.2 Consolidate state transitions
-  - [ ] 2.3 Add unit tests for skills
-- [ ] 3.0 Clean up equipment slot management in `Scripts/item_manager.gd`
-  - [ ] 3.1 Replace TODO with defined slot enumeration
-  - [ ] 3.2 Update equip/unequip functions
-  - [ ] 3.3 Add slot validation tests
-- [ ] 4.0 Centralize HUD update logic and signal connections
-  - [ ] 4.1 Move repeated HUD update code into helpers
-  - [ ] 4.2 Connect signals through single handler
-  - [ ] 4.3 Test HUD updates on inventory and health change
-- [ ] 5.0 Review helper utilities and add missing comments
-  - [ ] 5.1 Audit unused helper methods
-  - [ ] 5.2 Add Godot-style docstrings


### PR DESCRIPTION
## Summary
- refine maintenance plan in `tasks-code-refactor.md`
- add detailed sub-tasks for each refactoring goal

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_6886688f2e5483258761991b1d587df4