### PR TITLE
Add subtasks to crafting maintenance PR

### DIFF
--- a/.project-management/current-prd/tasks-prd-item-crafting-expansion.md
+++ b/.project-management/current-prd/tasks-prd-item-crafting-expansion.md
@@ -1,0 +1,243 @@
+## Selected maintenance goal
+- 15 - Item Combination and Crafting Expansion
+
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Assets
+│   └── Fonts
+├── Defaults
+│   ├── Blocks
+│   ├── Mobs
+│   ├── Player
+│   ├── Projectiles
+│   ├── Shaders
+│   └── Sprites
+├── Documentation
+│   ├── Game_design
+│   ├── Game_development
+│   └── Modding
+├── FeatureList.md
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── README.md
+├── Scenes
+│   ├── ContentManager
+│   ├── Overmap
+│   ├── UI
+│   ├── input_manager.tscn
+│   └── player.tscn
+├── Scripts
+│   ├── AttributesWindow.gd
+│   ├── AttributesWindow.gd.uid
+│   ├── BuildManager.gd
+│   ├── BuildManager.gd.uid
+│   ├── BuildingMenu.gd
+│   ├── BuildingMenu.gd.uid
+│   ├── Camera.gd
+│   ├── Camera.gd.uid
+│   ├── CharacterWindow.gd
+│   ├── CharacterWindow.gd.uid
+│   ├── Chunk.gd
+│   ├── Chunk.gd.uid
+│   ├── ChunkLevel.gd
+│   ├── ChunkLevel.gd.uid
+│   ├── Client.gd
+│   ├── Client.gd.uid
+│   ├── Components
+│   ├── ConstructionGhost.gd
+│   ├── ConstructionGhost.gd.uid
+│   ├── CraftingMenu.gd
+│   ├── CraftingMenu.gd.uid
+│   ├── CtrlInventoryStackedCustom.gd
+│   ├── CtrlInventoryStackedCustom.gd.uid
+│   ├── CtrlInventoryStackedListItem.gd
+│   ├── CtrlInventoryStackedListItem.gd.uid
+│   ├── CtrlInventoryStackedlistHeaderItem.gd
+│   ├── CtrlInventoryStackedlistHeaderItem.gd.uid
+│   ├── Documentation.gd
+│   ├── Documentation.gd.uid
+│   ├── EquipmentSlot.gd
+│   ├── EquipmentSlot.gd.uid
+│   ├── EquippedItem.gd
+│   ├── EquippedItem.gd.uid
+│   ├── EscapeMenu.gd
+│   ├── EscapeMenu.gd.uid
+│   ├── FurnitureBlueprintSpawner.gd
+│   ├── FurnitureBlueprintSpawner.gd.uid
+│   ├── FurnitureBlueprintSrv.gd
+│   ├── FurnitureBlueprintSrv.gd.uid
+│   ├── FurnitureConstructionWindow.gd
+│   ├── FurnitureConstructionWindow.gd.uid
+│   ├── FurniturePhysicsSpawner.gd
+│   ├── FurniturePhysicsSpawner.gd.uid
+│   ├── FurniturePhysicsSrv.gd
+│   ├── FurniturePhysicsSrv.gd.uid
+│   ├── FurnitureStaticSpawner.gd
+│   ├── FurnitureStaticSpawner.gd.uid
+│   ├── FurnitureStaticSrv.gd
+│   ├── FurnitureStaticSrv.gd.uid
+│   ├── FurnitureWindow.gd
+│   ├── FurnitureWindow.gd.uid
+│   ├── GameOver.gd
+│   ├── GameOver.gd.uid
+│   ├── Gamedata
+│   ├── HeldItem.gd
+│   ├── HeldItem.gd.uid
+│   ├── Helper
+│   ├── Helper.gd
+│   ├── Helper.gd.uid
+│   ├── InventoryContainerListItem.gd
+│   ├── InventoryContainerListItem.gd.uid
+│   ├── InventoryWindow.gd
+│   ├── InventoryWindow.gd.uid
+│   ├── ItemAmmoEditor.gd
+│   ├── ItemAmmoEditor.gd.uid
+│   ├── ItemCraftEditor.gd
+│   ├── ItemCraftEditor.gd.uid
+│   ├── ItemDetector.gd
+│   ├── ItemDetector.gd.uid
+│   ├── ItemEditor.gd
+│   ├── ItemEditor.gd.uid
+│   ├── ItemFoodEditor.gd
+│   ├── ItemFoodEditor.gd.uid
+│   ├── ItemMagazineEditor.gd
+│   ├── ItemMagazineEditor.gd.uid
+│   ├── ItemMedicalEditor.gd
+│   ├── ItemMedicalEditor.gd.uid
+│   ├── ItemMeleeEditor.gd
+│   ├── ItemMeleeEditor.gd.uid
+│   ├── ItemRangedEditor.gd
+│   ├── ItemRangedEditor.gd.uid
+│   ├── ItemToolEditor.gd
+│   ├── ItemToolEditor.gd.uid
+│   ├── ItemWearableEditor.gd
+│   ├── ItemWearableEditor.gd.uid
+│   ├── LoadingScreen.gd
+│   ├── LoadingScreen.gd.uid
+│   ├── Mob
+│   ├── NonHUDclick.gd
+│   ├── NonHUDclick.gd.uid
+│   ├── OvermapGrid.gd
+│   ├── OvermapGrid.gd.uid
+│   ├── PlayerAttribute.gd
+│   ├── PlayerAttribute.gd.uid
+│   ├── PlayerShooting.gd
+│   ├── PlayerShooting.gd.uid
+│   ├── QuestTrackerUI.gd
+│   ├── QuestTrackerUI.gd.uid
+│   ├── QuestWindow.gd
+│   ├── QuestWindow.gd.uid
+│   ├── Runtimedata
+│   ├── WearableSlot.gd
+│   ├── WearableSlot.gd.uid
+│   ├── bullet.gd
+│   ├── bullet.gd.uid
+│   ├── container.gd
+│   ├── container.gd.uid
+│   ├── crafting_recipes_manager.gd
+│   ├── crafting_recipes_manager.gd.uid
+│   ├── gamedata.gd
+│   ├── gamedata.gd.uid
+│   ├── general.gd
+│   ├── general.gd.uid
+│   ├── hud.gd
+│   ├── hud.gd.uid
+│   ├── input_manager.gd
+│   ├── input_manager.gd.uid
+│   ├── item_manager.gd
+│   ├── item_manager.gd.uid
+│   ├── player.gd
+│   ├── player.gd.uid
+│   ├── runtimedata.gd
+│   ├── runtimedata.gd.uid
+│   ├── scene_selector.gd
+│   ├── scene_selector.gd.uid
+│   ├── target_manager.gd
+│   ├── target_manager.gd.uid
+│   ├── weapon.gd
+│   └── weapon.gd.uid
+├── Shaders
+│   ├── HideAbovePlayer.gdshader
+│   ├── HideAbovePlayer.gdshader.uid
+│   ├── HideAbovePlayerShadow.gdshader
+│   └── HideAbovePlayerShadow.gdshader.uid
+├── Sounds
+│   ├── Ambience
+│   ├── Music
+│   ├── SFX
+│   └── default_bus_layout.tres
+├── Tests
+│   └── Unit
+├── day_night.gd
+├── day_night.gd.uid
+├── day_night.tscn
+├── documentation.tscn
+├── entity_manager.gd
+├── entity_manager.gd.uid
+├── export_presets.cfg
+├── front_light.gd
+├── front_light.gd.uid
+├── front_light.tscn
+├── hud.tscn
+├── icon.svg
+├── icon.svg.import
+├── level_generation.tscn
+├── override.cfg
+├── project.godot
+├── scene_selector.tscn
+├── spot_light_3d.tscn
+├── spot_light_3d_2.tscn
+├── test_environment.gd
+├── test_environment.gd.uid
+├── test_environment.tscn
+└── torso.aseprite
+
+31 directories, 164 files
+```
+
+## Relevant Files
+### Proposed New Files
+- `Mods/Dimensionfall/Items/new_items.json` - JSON file describing three new craftable or combinational items.
+- `Mods/Dimensionfall/Items/new_item_icons` - Placeholder directory for new item icons.
+- `/Tests/Unit/test_new_items.gd` - Tests ensuring new items load correctly and crafting logic works.
+
+### Existing Files Modified
+- `Mods/Dimensionfall/Items/Items.json` - Add new item entries and craft recipes.
+- `Scripts/Runtimedata/RItems.gd` - Ensure runtime loading includes new item sprites.
+- `Scripts/CraftingMenu.gd` - Update menu if needed to reference new craftable items.
+
+### Files To Remove
+- *(none)*
+
+### Notes
+- Unit tests should typically be placed in `/Tests/Unit/`.
+
+## Tasks
+- [ ] 1.0 Review existing items and design three new crafting combinations
+  - [ ] 1.1 Inspect `Mods/Dimensionfall/Items/Items.json` to understand current categories
+  - [ ] 1.2 Draft three new items mixing existing materials or introducing new ones
+  - [ ] 1.3 Outline craft recipes and usage notes for each item
+- [ ] 2.0 Create JSON definitions for the new items
+  - [ ] 2.1 Create `Mods/Dimensionfall/Items/new_items.json` containing the item definitions
+  - [ ] 2.2 Append references to these items in `Items.json`
+  - [ ] 2.3 Validate JSON structure by loading the file in Godot
+- [ ] 3.0 Add placeholder textures for the new items
+  - [ ] 3.1 Save placeholder PNGs in `Mods/Dimensionfall/Items/new_item_icons`
+  - [ ] 3.2 Reference textures correctly in `new_items.json`
+- [ ] 4.0 Update runtime scripts to load and reference the new items
+  - [ ] 4.1 Extend `Scripts/Runtimedata/RItems.gd` initialization to include new item sprites
+  - [ ] 4.2 Update `Scripts/CraftingMenu.gd` to display the new craft recipes
+  - [ ] 4.3 Confirm `ItemProtosets.tres` remains consistent after changes
+- [ ] 5.0 Implement unit tests validating crafting functionality and item loading
+  - [ ] 5.1 Write `Tests/Unit/test_new_items.gd` to ensure new items load correctly
+  - [ ] 5.2 Add tests verifying craft recipes produce expected outputs
+  - [ ] 5.3 Run all tests to confirm existing functionality remains intact
+
+*End of document*


### PR DESCRIPTION
## Summary
- expand the item-crafting maintenance task list
- add subtask details for analysis, JSON editing, textures, runtime updates, and testing

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_68866f2ba3dc8325b334e96aace82132