### PR TITLE
Add forest ruins map template

### DIFF
--- a/Mods/Dimensionfall/Maps/forest_ruins.json
+++ b/Mods/Dimensionfall/Maps/forest_ruins.json
@@ -1,0 +1,19 @@
+{
+    "areas": [],
+    "categories": [
+        "Forest"
+    ],
+    "connections": {
+        "east": "ground",
+        "north": "ground",
+        "south": "ground",
+        "west": "ground"
+    },
+    "description": "Ruins of a collapsed cabin hidden deep in the woods, now overgrown and silent.",
+    "id": "forest_ruins",
+    "levels": [[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[],[]],
+    "mapheight": 32,
+    "mapwidth": 32,
+    "name": "Forest Ruins",
+    "weight": 500
+}


### PR DESCRIPTION
## Summary
- categorize new 'forest_ruins' map under Forest category
- set up basic connections and 21 empty levels for manual editing later

## Testing
- `godot --headless --import` *(fails: command not found)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a2beb2a0832586679969a6ad2b79