### PR TITLE
Implement reload signal flow

### DIFF
--- a/.project-management/current-prd/tasks-decouple-scripts-scenes.md
+++ b/.project-management/current-prd/tasks-decouple-scripts-scenes.md
@@ -58,6 +58,8 @@
 - `Scenes/player.tscn`
 - `Scripts/hud.gd`
 - `Scripts/PlayerShooting.gd`
+- `Scripts/Helper/SignalBroker/player_input_signal_broker.gd`
+- `Scripts/input_manager.gd`
 
 ### Proposed New Files
 - `/Tests/Unit/test_hud_signals.gd` - Unit tests verifying HUD emits and receives signals correctly.
@@ -67,6 +69,8 @@
 - `hud.tscn` - remove NodePath properties referencing other scenes.
 - `Scenes/player.tscn` - update to remove NodePath linking to HUD.
 - `Scripts/PlayerShooting.gd` - replace `player` NodePath with signal connection.
+- `Scripts/Helper/SignalBroker/player_input_signal_broker.gd` - add reload_weapon signal.
+- `Scripts/input_manager.gd` - emit reload_weapon signal on input.
 
 ### Files To Remove
 - none
@@ -81,7 +85,7 @@
   - [ ] 2.3 Remove old NodePath exports from hud.gd.
 - [ ] 3.0 Refactor Player and PlayerShooting to rely on signals instead of direct NodePaths.
   - [ ] 3.1 Emit signals from player.gd for state changes.
-  - [c] 3.2 Update PlayerShooting.gd to use signals instead of NodePaths.
+  - [x] 3.2 Update PlayerShooting.gd to use signals instead of NodePaths.
   - [ ] 3.3 Connect Player signals to HUD via signal broker.
 - [ ] 4.0 Update scenes to remove exported NodePath properties and wire up signal connections.
   - [ ] 4.1 Remove NodePath exports from hud.tscn and player.tscn.

--- a/Scripts/Helper/SignalBroker/player_input_signal_broker.gd
+++ b/Scripts/Helper/SignalBroker/player_input_signal_broker.gd
@@ -21,3 +21,8 @@ static func interact() -> Signal:
 # Signal emitted with the player's desired movement vector
 static func movement_vector() -> Signal:
 	return SignalFactory.get_signal_with_key("movement_vector", 0, ["vector", TYPE_VECTOR2])
+
+
+# Signal emitted when the reload key is pressed
+static func reload_weapon() -> Signal:
+	return SignalFactory.get_signal_with_key("reload_weapon", 0)

--- a/Scripts/PlayerShooting.gd
+++ b/Scripts/PlayerShooting.gd
@@ -12,6 +12,7 @@ var _bullet_count: int = 0
 
 func _ready() -> void:
 	Helper.signal_broker.projectile_spawned.connect(_on_projectile_spawned)
+	PlayerInputSignalBroker.reload_weapon().connect(_on_reload_weapon)
 
 
 func _on_projectile_spawned(projectile: Node, instigator: RID) -> void:
@@ -27,34 +28,23 @@ func reset_bullet_count() -> void:
 	_bullet_count = 0
 
 
-func _input(event):
-	# Return early if no weapons are equipped
+func _on_reload_weapon() -> void:
 	if not left_hand_item or not right_hand_item:
 		return
-
-	if event.is_action_pressed("reload_weapon"):
-		if General.is_action_in_progress:
-			return
-		# Check if both weapons can be reloaded
-		if left_hand_item.can_weapon_reload() and right_hand_item.can_weapon_reload():
-			# Compare the current ammo to decide which weapon to reload
-			if left_hand_item.get_current_ammo() < right_hand_item.get_current_ammo():
-				left_hand_item.reload_weapon()
-			elif left_hand_item.get_current_ammo() > right_hand_item.get_current_ammo():
-				right_hand_item.reload_weapon()
-			else:
-				# If both have equal ammo, reload the left hand first
-				if left_hand_item.can_weapon_reload():
-					# Only the left hand weapon can be reloaded
-					left_hand_item.reload_weapon()
-				elif right_hand_item.can_weapon_reload():
-					# Only the right hand weapon can be reloaded
-					right_hand_item.reload_weapon()
+	if General.is_action_in_progress:
+		return
+	if left_hand_item.can_weapon_reload() and right_hand_item.can_weapon_reload():
+		if left_hand_item.get_current_ammo() < right_hand_item.get_current_ammo():
+			left_hand_item.reload_weapon()
+		elif left_hand_item.get_current_ammo() > right_hand_item.get_current_ammo():
+			right_hand_item.reload_weapon()
 		else:
-			# If both have equal ammo, reload the left hand first
 			if left_hand_item.can_weapon_reload():
-				# Only the left hand weapon can be reloaded
 				left_hand_item.reload_weapon()
 			elif right_hand_item.can_weapon_reload():
-				# Only the right hand weapon can be reloaded
 				right_hand_item.reload_weapon()
+	else:
+		if left_hand_item.can_weapon_reload():
+			left_hand_item.reload_weapon()
+		elif right_hand_item.can_weapon_reload():
+			right_hand_item.reload_weapon()

--- a/Scripts/input_manager.gd
+++ b/Scripts/input_manager.gd
@@ -28,7 +28,8 @@ func _input(event: InputEvent) -> void:
 		PlayerInputSignalBroker.run_toggled().emit(true)
 	elif event.is_action_released("run"):
 		PlayerInputSignalBroker.run_toggled().emit(false)
-
+	if event.is_action_pressed("reload_weapon"):
+		PlayerInputSignalBroker.reload_weapon().emit()
 	if event.is_action_pressed("interact"):
 		PlayerInputSignalBroker.interact().emit()
 


### PR DESCRIPTION
## Summary
- add `reload_weapon` signal to PlayerInputSignalBroker
- emit reload signal from InputManager
- connect PlayerShooting to reload signal
- update task list for completed subtask

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_68890b262ca483259688a94599195b69