### PR TITLE
Refactor Chunk generation logic

### DIFF
--- a/.project-management/current-prd/tasks-code-refactor.md
+++ b/.project-management/current-prd/tasks-code-refactor.md
@@ -61,7 +61,8 @@
 *(none at this stage)*
 
 ### Existing Files Modified
-*(none yet – to be determined in sub-tasks)*
+- `Scripts/Chunk.gd` - Refactored chunk generation functions
+- `Tests/Unit/test_chunk.gd` - Added coverage for new generation logic
 
 ### Files To Remove
 *(none)*
@@ -70,8 +71,8 @@
 - Unit tests are in `/Tests/Unit/`.
 
 ## Tasks
-- [ ] 1.0 Refactor `Scripts/Chunk.gd` for clarity and modular functions
-  - [ ] 1.1 Break chunk generation into smaller methods
-  - [ ] 1.2 Document generation steps with comments
-  - [ ] 1.3 Remove redundant loops and variables
-  - [ ] 1.4 Extend `/Tests/Unit/test_chunk.gd`
+- [x] 1.0 Refactor `Scripts/Chunk.gd` for clarity and modular functions
+  - [x] 1.1 Break chunk generation into smaller methods
+  - [x] 1.2 Document generation steps with comments
+  - [x] 1.3 Remove redundant loops and variables
+  - [x] 1.4 Extend `/Tests/Unit/test_chunk.gd`

--- a/Tests/Unit/test_chunk.gd
+++ b/Tests/Unit/test_chunk.gd
@@ -4,11 +4,13 @@ var test_chunk: Chunk
 var mock_level_manager: Node3D
 var mock_level_generator: Node3D
 
+
 # Runs before all tests.
 func before_all():
 	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
 	Runtimedata.reconstruct(custom_mods)
 	await get_tree().process_frame
+
 
 # Runs before each test.
 func before_each():
@@ -19,17 +21,15 @@ func before_each():
 	test_chunk.level_manager = mock_level_manager
 	test_chunk.level_generator = mock_level_generator
 
-	test_chunk.mypos = Vector3(32, 0, 64) # Example position (chunk (1, 2) with 32x32 blocks)
-	test_chunk.chunk_data = {
-		"id": "basic_test_map",
-		"rotation": 0
-	}
+	test_chunk.mypos = Vector3(32, 0, 64)  # Example position (chunk (1, 2) with 32x32 blocks)
+	test_chunk.chunk_data = {"id": "basic_test_map", "rotation": 0}
 
 	add_child(mock_level_manager)
 	add_child(mock_level_generator)
 	add_child(test_chunk)
 
 	await get_tree().process_frame
+
 
 # Runs after each test.
 func after_each():
@@ -40,9 +40,11 @@ func after_each():
 	if mock_level_generator:
 		mock_level_generator.queue_free()
 
+
 # Runs after all tests.
 func after_all():
 	Runtimedata.reset()
+
 
 # Test if the chunk initializes and spawns correctly.
 func test_chunk_load_unload():
@@ -50,20 +52,31 @@ func test_chunk_load_unload():
 	assert_true(test_chunk.is_in_group("chunks"), "Chunk is not added to 'chunks' group.")
 
 	# Test if chunk state is set correctly
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state.")
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state."
+	)
 
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
 
 	# Verify the state reset after generation
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.NEITHER, "Chunk should have reset to NEITHER state after generation.")
-	
+	assert_eq(
+		test_chunk.load_state,
+		Chunk.LoadStates.NEITHER,
+		"Chunk should have reset to NEITHER state after generation."
+	)
+
 	assert_eq(test_chunk.mypos, Vector3(32, 0, 64), "Chunk position is not set correctly.")
 	assert_eq(test_chunk.level_manager, mock_level_manager, "Level manager is not set correctly.")
-	assert_eq(test_chunk.level_generator, mock_level_generator, "Level generator is not set correctly.")
+	assert_eq(
+		test_chunk.level_generator, mock_level_generator, "Level generator is not set correctly."
+	)
 	assert_has(test_chunk.chunk_data, "id", "Chunk data does not contain 'id' key.")
 	assert_eq(test_chunk.chunk_data["id"], "basic_test_map", "Chunk data ID is not correct.")
-	
+
 	# Validate specific blocks on level 0 (which is ground floor)
 	var level_index = 0
 
@@ -85,15 +98,31 @@ func test_chunk_load_unload():
 	# Check (31, 31) -> "dot_tile", rotation 180 --> bottom-right block
 	var block_3131 = test_chunk.get_block_at(level_index, Vector2i(31, 31))
 	assert_eq(block_3131.get("id", ""), "dot_tile", "Block at (31, 31) is not 'dot_tile'.")
-	assert_eq(block_3131.get("rotation", 0.0), 180.0, "Block at (31, 31) does not have rotation 180.")
-
+	assert_eq(
+		block_3131.get("rotation", 0.0), 180.0, "Block at (31, 31) does not have rotation 180."
+	)
 
 	# Call `unload_chunk` and wait for the chunk to be null
 	# Awaiting the `chunk_unloaded` signal will produce an error in GUT somehow, so don't do that
 	test_chunk.unload_chunk()
 	# Verify that the load state is `UNLOADING`)
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.UNLOADING, "Chunk load_state should be UNLOADING.")
-	var chunk_is_unloaded = func():
-		return test_chunk == null
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.UNLOADING, "Chunk load_state should be UNLOADING."
+	)
+	var chunk_is_unloaded = func(): return test_chunk == null
 	# Calls chunk_is_unloaded every second until it returns true and asserts on the returned value
-	assert_true(await wait_until(chunk_is_unloaded, 10, 1),"Chunk should be unloaded in 10 seconds")
+	assert_true(
+		await wait_until(chunk_is_unloaded, 10, 1), "Chunk should be unloaded in 10 seconds"
+	)
+
+
+# Verify processed_level_data contains no features for basic_test_map
+func test_processed_level_data_defaults():
+	await wait_for_signal(test_chunk.chunk_generated, 5)
+	var data = test_chunk.processed_level_data
+	assert_true(data.has("furniture"))
+	assert_true(data.has("mobs"))
+	assert_true(data.has("itemgroups"))
+	assert_eq(data.furniture.size(), 0, "Expected no furniture in basic_test_map")
+	assert_eq(data.mobs.size(), 0, "Expected no mobs in basic_test_map")
+	assert_eq(data.itemgroups.size(), 0, "Expected no itemgroups in basic_test_map")


### PR DESCRIPTION
## Summary
- simplify chunk generation logic
- add helper for feature processing and navigation comments
- document generation steps
- extend chunk unit tests for processed data
- update tasks

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_6889176ee0a88325b43e6dd62499f3d6