### PR TITLE
Add maintenance tasks for map categorization

### DIFF
--- a/.project-management/current-prd/tasks-prd-map-categorization.md
+++ b/.project-management/current-prd/tasks-prd-map-categorization.md
@@ -1,0 +1,94 @@
+## Selected maintenance goal
+- 14: Map Categorization and Template Generation
+
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── Assets
+│   └── Fonts
+├── Defaults
+│   ├── Blocks
+│   ├── Mobs
+│   ├── Player
+│   ├── Projectiles
+│   ├── Shaders
+│   └── Sprites
+├── Documentation
+│   ├── Game_design
+│   ├── Game_development
+│   └── Modding
+├── FeatureList.md
+├── Images
+│   ├── Icons
+│   └── Main menu
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── Media
+│   ├── Catax_basic.png
+│   ├── Catax_basic.png.import
+│   ├── Catax_basic_zoomed_out.png
+│   ├── Catax_basic_zoomed_out.png.import
+│   ├── Catax_content_editor.png
+│   ├── Catax_content_editor.png.import
+│   ├── Catax_crafting_editor.png
+│   ├── Catax_crafting_editor.png.import
+│   ├── Catax_furniture_editor.png
+│   ├── Catax_furniture_editor.png.import
+│   ├── Catax_item_editor.png
+│   ├── Catax_item_editor.png.import
+│   ├── Catax_itemgroup_editor.png
+│   ├── Catax_itemgroup_editor.png.import
+│   ├── Catax_map_editor.png
+│   ├── Catax_map_editor.png.import
+│   ├── Catax_map_editor_area_editor.png
+│   ├── Catax_map_editor_area_editor.png.import
+│   ├── Catax_map_editor_areas.png
+│   ├── Catax_map_editor_areas.png.import
+│   ├── Catax_map_editor_preview.png
+│   ├── Catax_map_editor_preview.png.import
+│   ├── Catax_mob_editor.png
+```
+
+## Relevant Files
+- `Mods/Dimensionfall/Maps/` - Existing map templates and categories
+- `Mods/Dimensionfall/Overmapareas/Overmapareas.json` - Overmap area configuration referencing available maps
+- `Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd` - Editor script that handles map categories
+- `/Tests/Unit/` - Unit tests referencing map data
+
+### Proposed New Files
+- `Mods/Dimensionfall/Maps/new_category_template_1.json` - Placeholder for a new map template
+- `Mods/Dimensionfall/Maps/new_category_template_2.json` - Placeholder for second map template
+
+### Existing Files Modified
+- `Mods/Dimensionfall/Overmapareas/Overmapareas.json` - Include new map categories and map references
+- `Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd` - Ensure new categories appear in editor lists
+
+### Files To Remove
+- None
+
+### Notes
+- Unit tests should typically be placed in `/Tests/Unit/`.
+
+## Tasks
+- [ ] 1.0 Audit current map categories and templates
+  - [ ] 1.1 Review `Overmapareas.json` for current categories
+  - [ ] 1.2 Document existing templates in `Mods/Dimensionfall/Maps`
+- [ ] 2.0 Add two additional map categories to the project
+  - [ ] 2.1 Append new categories to `Overmapareas.json`
+  - [ ] 2.2 Ensure editor lists show the categories
+- [ ] 3.0 Create two new map JSON templates for each of the five categories
+  - [ ] 3.1 Duplicate an existing template as a base
+  - [ ] 3.2 Customize tile sets for variety
+- [ ] 4.0 Update Overmapareas configuration to reference new maps
+  - [ ] 4.1 List new maps for each category in `Overmapareas.json`
+- [ ] 5.0 Verify map editor lists and unit tests recognize the new categories
+  - [ ] 5.1 Launch map editor and confirm new categories
+  - [ ] 5.2 Add unit tests covering the new categories
+
+*End of document*

--- a/.project-management/current-prd/tasks-prd-map-categorization.md
+++ b/.project-management/current-prd/tasks-prd-map-categorization.md
@@ -57,17 +57,10 @@
 
 ## Relevant Files
 - `Mods/Dimensionfall/Maps/` - Existing map templates and categories
-- `Mods/Dimensionfall/Overmapareas/Overmapareas.json` - Overmap area configuration referencing available maps
-- `Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd` - Editor script that handles map categories
-- `/Tests/Unit/` - Unit tests referencing map data
 
 ### Proposed New Files
-- `Mods/Dimensionfall/Maps/new_category_template_1.json` - Placeholder for a new map template
-- `Mods/Dimensionfall/Maps/new_category_template_2.json` - Placeholder for second map template
+- `Mods/Dimensionfall/Maps/my_new_map.json` - Rename based on the contents of the map
 
-### Existing Files Modified
-- `Mods/Dimensionfall/Overmapareas/Overmapareas.json` - Include new map categories and map references
-- `Scenes/ContentManager/Mapeditor/Scripts/mapeditor.gd` - Ensure new categories appear in editor lists
 
 ### Files To Remove
 - None
@@ -78,17 +71,9 @@
 ## Tasks
 - [ ] 1.0 Audit current map categories and templates
   - [ ] 1.1 Review `Overmapareas.json` for current categories
-  - [ ] 1.2 Document existing templates in `Mods/Dimensionfall/Maps`
-- [ ] 2.0 Add two additional map categories to the project
-  - [ ] 2.1 Append new categories to `Overmapareas.json`
-  - [ ] 2.2 Ensure editor lists show the categories
+- [ ] 2.0 come up with two additional map categories to the project
+  - [ ] 2.1 Remember these categories for when we create the new maps of all categories
 - [ ] 3.0 Create two new map JSON templates for each of the five categories
-  - [ ] 3.1 Duplicate an existing template as a base
-  - [ ] 3.2 Customize tile sets for variety
-- [ ] 4.0 Update Overmapareas configuration to reference new maps
-  - [ ] 4.1 List new maps for each category in `Overmapareas.json`
-- [ ] 5.0 Verify map editor lists and unit tests recognize the new categories
-  - [ ] 5.1 Launch map editor and confirm new categories
-  - [ ] 5.2 Add unit tests covering the new categories
+  - [ ] 3.1 Create new maps based on the 5 categories
 
 *End of document*


### PR DESCRIPTION
## Summary
- refine maintenance tasks for map categorization and template generation

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_688cd62730a88325bf7dda35ffae057d