### PR TITLE
Expand tile rotation tasks with sub steps

### DIFF
--- a/.project-management/current-prd/tasks-prd-rotate-tile-feature.md
+++ b/.project-management/current-prd/tasks-prd-rotate-tile-feature.md
@@ -1,0 +1,57 @@
+## Pre-Feature Development Project Tree
+```
+.
+├── AGENTS.md
+├── FeatureList.md
+├── ItemProtosets.tres
+├── LICENSE
+├── LevelGenerator.gd
+├── LevelGenerator.gd.uid
+├── LevelManager.gd
+├── LevelManager.gd.uid
+├── Main_menu_buttons.tres
+├── README.md
+├── Assets
+├── Defaults
+├── Images
+├── Mods
+├── Scenes
+├── Scripts
+├── Shaders
+├── Sounds
+└── Textures
+```
+
+## Relevant Files
+- `Scripts/Chunk.gd` - Contains the `rotate_level_clockwise` function.
+- `.project-management/current-prd/feature-specification.md` - Background details on using the `feature` dictionary.
+
+### Proposed New Files
+- *(none at this stage)*
+
+### Existing Files Modified
+- `Scripts/Chunk.gd` - Refactor rotation logic to rely on `tile.feature`.
+
+### Notes
+- Follow GDScript 4 syntax and Godot 4.4 best practices.
+- No additional automated tests are required for this feature.
+
+## Tasks
+- [ ] 1.0 Refactor `rotate_level_clockwise` in `Scripts/Chunk.gd` to use `tile.feature` for rotation as described in `.project-management/current-prd/feature-specification.md`.
+  - [ ] 1.1 Locate the `rotate_level_clockwise` function in `Scripts/Chunk.gd`.
+  - [ ] 1.2 Replace checks for `tile.furniture` with logic that reads from `tile.feature`.
+  - [ ] 1.3 Ensure that rotated features update their `rotation` field correctly.
+  - [ ] 1.4 Run `gdformat Scripts/Chunk.gd` to apply consistent formatting.
+- [ ] 2.0 Implement rotation handling for all feature types (`furniture`, `mob`, `mobgroup`, `itemgroup`) that include a `rotation` field.
+  - [ ] 2.1 Expand the rotation logic to handle each feature type.
+  - [ ] 2.2 Verify that mobs and item groups preserve their orientation after rotation.
+- [ ] 3.0 Audit the codebase and replace any remaining references to `tile.furniture` with `tile.feature`.
+  - [ ] 3.1 Search the repository for `tile.furniture` occurrences.
+  - [ ] 3.2 Update each script to reference `tile.feature` instead.
+- [ ] 4.0 Remove legacy furniture rotation logic and ensure no code writes to `tile.furniture`.
+  - [ ] 4.1 Delete any obsolete helper functions tied to the `furniture` field.
+  - [ ] 4.2 Confirm that new saves no longer contain the deprecated property.
+- [ ] 5.0 Update documentation to reflect the unified feature rotation approach.
+  - [ ] 5.1 Document feature rotation behavior in `Documentation` or README.
+  - [ ] 5.2 Mention the removal of the `furniture` property.
+*End of document*


### PR DESCRIPTION
## Summary
- fill out sub-tasks in the rotate tile feature task list
- simplify project tree listing

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`

------
https://chatgpt.com/codex/tasks/task_e_688cd83727a08325a2e8dab6dfe7f3fe