### PR TITLE
Add NPC tile tasks

### DIFF
--- a/.project-management/current-prd/tasks-prd-npc_tile.md
+++ b/.project-management/current-prd/tasks-prd-npc_tile.md
@@ -55,8 +55,6 @@
 - [ ] 2.0 Implement painting logic that places `npc_tile` with rotation and replaces existing `mob`, `mobgroup`, `furniture`, or `itemgroup` features (`Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd`).
   - [ ] 2.1 Extend painting function to recognize `npc_tile` selection and capture rotation data.
   - [ ] 2.2 Implement feature-replacement logic so `npc_tile` overwrites `mob`, `mobgroup`, `furniture`, or `itemgroup` on the same tile.
-  - [ ] 2.3 Add visual feedback to show placement with correct rotation.
-  - [ ] 2.4 Confirm that undo/redo operations properly record `npc_tile` placements.
 - [ ] 3.0 Persist `npc_tile` coordinates and rotation within map serialization (`Scripts/Gamedata/DMap.gd`, `Scripts/Gamedata/DMaps.gd`).
   - [ ] 3.1 Modify `DMap` to store `npc_tile` positions and rotation as part of map data.
   - [ ] 3.2 Update serialization methods to write `npc_tile` entries with rotation to file.

--- a/.project-management/current-prd/tasks-prd-npc_tile.md
+++ b/.project-management/current-prd/tasks-prd-npc_tile.md
@@ -1,0 +1,75 @@
+## Pre-Feature Development Project Tree
+- Assets
+- Defaults
+- Documentation
+- Images
+- Media
+- Mods
+  - Backrooms
+  - Core
+  - Dimensionfall
+  - Test
+- Scenes
+  - ContentManager
+  - Overmap
+  - UI
+- Scripts
+  - Components
+  - Gamedata
+  - Helper
+  - Mob
+  - Runtimedata
+- Shaders
+- Sounds
+  - Ambience
+  - Music
+  - SFX
+- Tests
+  - Unit
+- Textures
+
+## Relevant Files
+### Proposed New Files
+- `Tests/Unit/tilebrush_npc_tile_test.gd` - Unit tests for `npc_tile` brush placement and rotation.
+- `Tests/Unit/dmap_npc_tile_test.gd` - Unit tests for serialization and deserialization of `npc_tile` data.
+- `Tests/Unit/map_manager_npc_tile_test.gd` - Unit tests for `npc_tile` map processing behavior.
+
+### Existing Files Modified
+- `Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd` - Adds `npc_tile` button to brush composer.
+- `Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd` - Implements painting logic for `npc_tile` with rotation and feature replacement.
+- `Scripts/Gamedata/DMap.gd` - Stores `npc_tile` coordinates and rotation.
+- `Scripts/Gamedata/DMaps.gd` - Serializes and deserializes `npc_tile` data.
+- `Scripts/Helper/map_manager.gd` - Processes `npc_tile` entries and allows overwrites.
+
+### Notes
+- Follow GDScript 4 syntax and Godot 4.4 best practices.
+- Use tabs for indentation.
+- Run `gdformat` on changed scripts and execute GUT tests after modifications.
+- `npc_tile` uses `res://Scenes/ContentManager/Mapeditor/Images/nulltile_32.png` as its icon.
+
+## Tasks
+- [ ] 1.0 Add `npc_tile` brush option alongside `null_tile` in the map editor brush composer (`Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd`).
+  - [ ] 1.1 Update brush options list to include `npc_tile`, ensuring it appears in the composer UI.
+  - [ ] 1.2 Implement UI logic to select `npc_tile`, mirroring the selection flow used for `null_tile`.
+  - [ ] 1.3 Validate that selection updates internal state correctly and triggers necessary callbacks.
+- [ ] 2.0 Implement painting logic that places `npc_tile` with rotation and replaces existing `mob`, `mobgroup`, `furniture`, or `itemgroup` features (`Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd`).
+  - [ ] 2.1 Extend painting function to recognize `npc_tile` selection and capture rotation data.
+  - [ ] 2.2 Implement feature-replacement logic so `npc_tile` overwrites `mob`, `mobgroup`, `furniture`, or `itemgroup` on the same tile.
+  - [ ] 2.3 Add visual feedback to show placement with correct rotation.
+  - [ ] 2.4 Confirm that undo/redo operations properly record `npc_tile` placements.
+- [ ] 3.0 Persist `npc_tile` coordinates and rotation within map serialization (`Scripts/Gamedata/DMap.gd`, `Scripts/Gamedata/DMaps.gd`).
+  - [ ] 3.1 Modify `DMap` to store `npc_tile` positions and rotation as part of map data.
+  - [ ] 3.2 Update serialization methods to write `npc_tile` entries with rotation to file.
+  - [ ] 3.3 Update deserialization to read `npc_tile` data and restore it into `DMap`.
+  - [ ] 3.4 Ensure backward compatibility by handling maps without `npc_tile` data gracefully.
+- [ ] 4.0 Handle `npc_tile` entries during map processing, logging their presence and allowing later features to overwrite them (`Scripts/Helper/map_manager.gd`).
+  - [ ] 4.1 Extend map processing loop to detect `npc_tile` entries and log them for debugging.
+  - [ ] 4.2 Implement overwrite rules so subsequent features can replace `npc_tile` entries if needed.
+  - [ ] 4.3 Verify that processing order respects existing feature priorities.
+- [ ] 5.0 Add tests covering brush placement, serialization/deserialization, and map processing of `npc_tile` entries (`Tests/Unit/`).
+  - [ ] 5.1 Write unit tests for brush placement and rotation handling in `tilebrush.gd`.
+  - [ ] 5.2 Write serialization/deserialization tests ensuring `npc_tile` data persists accurately.
+  - [ ] 5.3 Add tests for map processing logic confirming correct overwrite behavior and logging.
+  - [ ] 5.4 Run all existing test suites to ensure no regressions.
+
+*End of document*


### PR DESCRIPTION
## Summary
- add planning tasks for introducing npc_tile feature in map editor

## Testing
- `godot --headless --import` *(fails: Unrecognized UID "uid://b4d5nmc2jtjmw")*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(failed: log file not generated, view_panner error)*

------
https://chatgpt.com/codex/tasks/task_e_68933bd3a134832580175d61d014834b