### PR TITLE
feat: add npc tile brush option

### DIFF
--- a/.project-management/current-prd/tasks-prd-npc_tile.md
+++ b/.project-management/current-prd/tasks-prd-npc_tile.md
@@ -48,10 +48,10 @@
 - `npc_tile` uses `res://Scenes/ContentManager/Mapeditor/Images/nulltile_32.png` as its icon.
 
 ## Tasks
-- [ ] 1.0 Add `npc_tile` brush option alongside `null_tile` in the map editor brush composer (`Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd`).
-  - [ ] 1.1 Update brush options list to include `npc_tile`, ensuring it appears in the composer UI.
-  - [ ] 1.2 Implement UI logic to select `npc_tile`, mirroring the selection flow used for `null_tile`.
-  - [ ] 1.3 Validate that selection updates internal state correctly and triggers necessary callbacks.
+ - [x] 1.0 Add `npc_tile` brush option alongside `null_tile` in the map editor brush composer (`Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd`).
+  - [x] 1.1 Update brush options list to include `npc_tile`, ensuring it appears in the composer UI.
+  - [x] 1.2 Implement UI logic to select `npc_tile`, mirroring the selection flow used for `null_tile`.
+  - [x] 1.3 Validate that selection updates internal state correctly and triggers necessary callbacks.
 - [ ] 2.0 Implement painting logic that places `npc_tile` with rotation and replaces existing `mob`, `mobgroup`, `furniture`, or `itemgroup` features (`Scenes/ContentManager/Mapeditor/Scripts/tilebrush.gd`).
   - [ ] 2.1 Extend painting function to recognize `npc_tile` selection and capture rotation data.
   - [ ] 2.2 Implement feature-replacement logic so `npc_tile` overwrites `mob`, `mobgroup`, `furniture`, or `itemgroup` on the same tile.

--- a/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
+++ b/Scenes/ContentManager/Mapeditor/Scripts/mapeditor_brushcomposer.gd
@@ -3,29 +3,29 @@ extends VBoxContainer
 # This script is intended to be used with the mapeditor_brushcomposer.tscn
 # This brushcomposer allows the user to compose a brush made up of one or more
 # tile brushes. When a brush is selected, you can hold ctrl and click another brush
-# to add it to the selected brushes. When 2 or more brushes are selected, the map 
+# to add it to the selected brushes. When 2 or more brushes are selected, the map
 # editor will pick one at random and paint it onto the map.
 
 # This allows you to compose a custom brush. For example, if I want to add a grass
-# field where some dirt patches are randomly added, I can add the grass tile six times 
+# field where some dirt patches are randomly added, I can add the grass tile six times
 # and the dirt tile 1 time and then start painting to have it randomly distributed.
 
 #Additional features:
 
-	# TODO: Have a button to add a 'null' tile that will include an empty brush. 
-	# To demonstrate the use case: Add 6 null tiles and 1 mob and you can 
-	# randomly distribute mobs on your map, having them spawn 1 in 7 chance
-	
-	# TODO: Have a button to toggle whether you want to pick a random tile each brush 
-	# stroke or each click. When selecting 'each brush stroke', it will pick a 
-	# random one each time it would paint a tile, so when clicking and dragging. 
-	# When selecting 'each click', it will pick one tile and keep painting it 
-	# until you release the mouse button. This is useful for painting house 
-	# floors where you might want a random floor, but have each tile in the 
-	# floor be the same.
-	
-	# TODO: Add an erase button to clear the brush
-	# TODO: Have the brush be remembered when leaving the map editor
+# TODO: Have a button to add a 'null' tile that will include an empty brush.
+# To demonstrate the use case: Add 6 null tiles and 1 mob and you can
+# randomly distribute mobs on your map, having them spawn 1 in 7 chance
+
+# TODO: Have a button to toggle whether you want to pick a random tile each brush
+# stroke or each click. When selecting 'each brush stroke', it will pick a
+# random one each time it would paint a tile, so when clicking and dragging.
+# When selecting 'each click', it will pick one tile and keep painting it
+# until you release the mouse button. This is useful for painting house
+# floors where you might want a random floor, but have each tile in the
+# floor be the same.
+
+# TODO: Add an erase button to clear the brush
+# TODO: Have the brush be remembered when leaving the map editor
 
 @export var brush_container: Control
 @export var tileBrush: PackedScene = null
@@ -39,10 +39,12 @@ extends VBoxContainer
 signal brush_added(brush: Control)
 signal brush_removed(brush: Control)
 
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Set custom can_drop_func and drop_func for the brushcontainer, use default drag_func
 	brush_container.set_drag_forwarding(Callable(), custom_can_drop_data, custom_drop_data)
+
 
 # Function to clear the children of brush_container
 func clear_brush_container():
@@ -51,14 +53,20 @@ func clear_brush_container():
 		brush_removed.emit(child)
 		child.queue_free()
 
+
 # Extracts necessary properties from the original_tilebrush and returns them in a dictionary.
 # This function collects the texture, entityID, and entityType from the original tilebrush.
 func extract_tilebrush_properties(original_tilebrush: Control) -> Dictionary:
-	return {
-		"texture": original_tilebrush.get_texture(),
-		"entityID": original_tilebrush.entityID,
-		"entityType": original_tilebrush.entityType
-	} if original_tilebrush else {}
+	return (
+		{
+			"texture": original_tilebrush.get_texture(),
+			"entityID": original_tilebrush.entityID,
+			"entityType": original_tilebrush.entityType
+		}
+		if original_tilebrush
+		else {}
+	)
+
 
 # Creates a new tilebrush instance using the provided properties dictionary and adds it to the brush_container.
 # The properties dictionary should contain the texture, entityID, and entityType.
@@ -74,26 +82,26 @@ func add_tilebrush_to_container_with_properties(properties: Dictionary):
 	brushInstance.set_minimum_size(Vector2(32, 32))
 	brush_container.add_content_item(brushInstance)
 	brush_added.emit(brushInstance)
-	
+
 	# Add the brush to the area data if an area is selected
 	add_brush_to_area_data(properties)
+
 
 # Function to add a brush to the area data
 func add_brush_to_area_data(properties: Dictionary):
 	# Get the selected area name
 	var selected_area_name = get_selected_area_name()
-	
+
 	# If "None" is selected, do nothing
 	if selected_area_name == "None":
 		return
-	
+
 	# Find the selected area data in map_areas
 	var selected_area_data = get_selected_area_data(selected_area_name)
 	if selected_area_data.is_empty():
 		print_debug("Selected area not found in mapData.")
 		return
-	
-	
+
 	# Add the brush to the appropriate category in the area data
 	var entity_data = {"id": properties.entityID, "count": 1, "type": properties.entityType}
 	if properties.entityType == "tile":
@@ -104,10 +112,12 @@ func add_brush_to_area_data(properties: Dictionary):
 	# Update the map areas in gridContainer
 	gridContainer.update_map_areas(gridContainer.get_map_areas())
 
+
 # Will append the entity id to the area list if it's not already in there
 func add_entity_to_area(area_list: Array, entity_data: Dictionary):
 	if not entity_exists_in_array(area_list, entity_data["id"]):
 		area_list.append(entity_data)
+
 
 # Extracts properties from the original_tilebrush and uses them to create and add a new tilebrush instance to the container.
 # This function first calls extract_tilebrush_properties to get the properties and then
@@ -116,10 +126,12 @@ func add_tilebrush_to_container(original_tilebrush: Control):
 	var properties = extract_tilebrush_properties(original_tilebrush)
 	add_tilebrush_to_container_with_properties(properties)
 
+
 # Clears the brushcomposer and adds the new brush
 func replace_all_with_brush(original_tilebrush: Control):
 	clear_brush_container()
 	add_tilebrush_to_container(original_tilebrush)
+
 
 # Function to handle tilebrush click and remove it from the container
 func _on_tilebrush_clicked(brush):
@@ -128,23 +140,24 @@ func _on_tilebrush_clicked(brush):
 	remove_brush_from_area_data(extract_tilebrush_properties(brush))
 	brush_removed.emit(brush)
 
+
 # Function to remove a brush from the area data
 func remove_brush_from_area_data(properties: Dictionary):
 	# Get the selected area name
 	var selected_area_name = get_selected_area_name()
-	
+
 	# If "None" is selected, do nothing
 	if selected_area_name == "None":
 		return
-	
+
 	var selected_area_data = get_selected_area_data(selected_area_name)
 	if selected_area_data.is_empty():
 		print_debug("Selected area not found in mapData.")
 		return
-	
+
 	# Remove the brush from the entities in the area data
 	remove_entity_from_area(selected_area_data["entities"], properties.entityID)
-	
+
 	# Update the map areas in gridContainer
 	gridContainer.update_map_areas(gridContainer.get_map_areas())
 
@@ -170,15 +183,15 @@ func get_random_brush() -> Control:
 			itemgroup_brushes.append(child)
 		else:
 			valid_brushes.append(child)
-	
+
 	# If no valid brushes are found, return a random itemgroup brush
 	if valid_brushes.size() == 0 and itemgroup_brushes.size() > 0:
 		return itemgroup_brushes[randi() % itemgroup_brushes.size()]
-	
+
 	# If there are valid brushes, return a random valid brush
 	if valid_brushes.size() > 0:
 		return valid_brushes.pick_random()
-	
+
 	# If no brushes are available, return null
 	return null
 
@@ -193,12 +206,12 @@ func get_all_brushes() -> Array:
 func get_itemgroup_entity_ids() -> Array:
 	var children = brush_container.get_content_items()
 	var itemgroup_ids = []
-	
+
 	# Loop through the children and collect entityIDs of those with entityType "itemgroup"
 	for child in children:
 		if child.entityType == "itemgroup":
 			itemgroup_ids.append(child.entityID)
-	
+
 	# Return the list of itemgroup IDs
 	return itemgroup_ids
 
@@ -228,7 +241,7 @@ func custom_can_drop_data(_mypos, dropped_data: Dictionary) -> bool:
 	# Check if the data dictionary has the 'id' property
 	if not dropped_data or not dropped_data.has("id"):
 		return false
-	
+
 	# Fetch itemgroup data by ID from the Gamedata to ensure it exists and is valid
 	if not Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.has_id(dropped_data["id"]):
 		return false
@@ -253,9 +266,10 @@ func custom_drop_data(_mypos, dropped_data):
 		if not Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.has_id(itemgroup_id):
 			print_debug("No data found for ID: " + itemgroup_id)
 			return
-		
+
 		var properties: Dictionary = {
-			"texture": Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.sprite_by_id(itemgroup_id),
+			"texture":
+			Gamedata.mods.by_id(dropped_data["mod_id"]).itemgroups.sprite_by_id(itemgroup_id),
 			"entityID": itemgroup_id,
 			"entityType": "itemgroup"
 		}
@@ -273,33 +287,29 @@ func get_selected_area_name() -> String:
 func generate_area_data() -> Dictionary:
 	# Get all brushes from the brush container
 	var brushes = get_all_brushes()
-	
+
 	# Return if the brush list is empty
 	if brushes.is_empty():
 		return {}
-	
+
 	# Initialize the default area data
 	var area_data: Dictionary = {
-		"id": "area1",
-		"tiles": [],
-		"entities": [],
-		"rotate_random": false,
-		"spawn_chance": 100
+		"id": "area1", "tiles": [], "entities": [], "rotate_random": false, "spawn_chance": 100
 	}
-	
+
 	# Loop over each brush and sort by entityType
 	for brush in brushes:
 		var entity_type: String = brush.entityType
 		var entity_id: String = brush.entityID
 		var entity_data = {"id": entity_id, "count": 1, "type": entity_type}
-		
+
 		# Only add the entities once and do not add duplicates of the same id
 		match entity_type:
 			"tile":
 				add_entity_to_area(area_data["tiles"], entity_data)
 			_:
 				add_entity_to_area(area_data["entities"], entity_data)
-	
+
 	# Check if a area name is selected
 	var selected_area_name: String = get_selected_area_name()
 	if selected_area_name == "None":
@@ -307,12 +317,12 @@ func generate_area_data() -> Dictionary:
 		area_data["id"] = new_id
 		areas_option_button.add_item(new_id)  # Ensure the new ID is added to the areas_option_button
 		areas_option_button.select(areas_option_button.get_item_count() - 1)  # Select the newly added item
-	else: # One of the areas is already selected
+	else:  # One of the areas is already selected
 		area_data["id"] = selected_area_name
-	
+
 	# Set rotate_random if the rotation button is pressed
 	area_data["rotate_random"] = rotation_button.button_pressed
-	
+
 	return area_data
 
 
@@ -349,33 +359,35 @@ func _on_map_area_settings_button_button_up():
 func _on_areas_option_button_item_selected(index):
 	# Let the gridcontainer handle the selection as well
 	gridContainer.on_areas_option_button_item_selected(areas_option_button, index)
-	
+
 	# Refresh the brush container based on the selected area
 	refresh_brush_container_from_selected_area()
+
 
 # Function to refresh the brush container based on the selected area
 func refresh_brush_container_from_selected_area():
 	var selected_area_name = get_selected_area_name()
-	
+
 	# If the selected area is "None", clear the brush container and return
 	if selected_area_name == "None":
 		clear_brush_container()
 		return
-		
+
 	# Find the selected area data in map_areas
 	var selected_area_data = get_selected_area_data(selected_area_name)
 	if selected_area_data.is_empty():
 		print_debug("Selected area not found in mapData.")
 		return
-	
+
 	# Clear all the brushes from the brush_container
 	clear_brush_container()
-	
+
 	# Add brushes from the selected area data to the brush_container
 	var tilesdata: Array = selected_area_data["tiles"]
 	add_brushes_from_area(tilesdata, "tile")
 	var entitiesdata: Array = selected_area_data["entities"]
 	add_brushes_from_area(entitiesdata)
+
 
 # Function to get the selected area data
 func get_selected_area_data(selected_area_name: String) -> Dictionary:
@@ -385,29 +397,43 @@ func get_selected_area_data(selected_area_name: String) -> Dictionary:
 			return area
 	return {}
 
+
 # Function to add tile brushes to the container based on entity type
 func add_brushes_from_area(entity_list: Array, entity_type: String = "entity"):
 	for entity in entity_list:
 		if entity["id"] == "null":
 			_on_null_tile_button_up()
 			continue
-		var properties: Dictionary = {
-			"entityID": entity["id"],
-			"entityType": entity_type
-		}
+		var properties: Dictionary = {"entityID": entity["id"], "entityType": entity_type}
 		var newtype: String = entity.get("type", "tile")
 		# Get the appropriate sprite based on the entity type
 		match newtype:
 			"tile":
-				properties["texture"] = Gamedata.mods.get_content_by_id(DMod.ContentType.TILES,entity["id"]).sprite
+				properties["texture"] = (
+					Gamedata.mods.get_content_by_id(DMod.ContentType.TILES, entity["id"]).sprite
+				)
 			"mob":
-				properties["texture"] = Gamedata.mods.get_content_by_id(DMod.ContentType.MOBS,entity["id"]).sprite
+				properties["texture"] = (
+					Gamedata.mods.get_content_by_id(DMod.ContentType.MOBS, entity["id"]).sprite
+				)
 			"furniture":
-				properties["texture"] = Gamedata.mods.get_content_by_id(DMod.ContentType.FURNITURES,entity["id"]).sprite
+				properties["texture"] = (
+					Gamedata
+					. mods
+					. get_content_by_id(DMod.ContentType.FURNITURES, entity["id"])
+					. sprite
+				)
 			"itemgroup":
-				properties["texture"] = Gamedata.mods.get_content_by_id(DMod.ContentType.ITEMGROUPS,entity["id"]).sprite
+				properties["texture"] = (
+					Gamedata
+					. mods
+					. get_content_by_id(DMod.ContentType.ITEMGROUPS, entity["id"])
+					. sprite
+				)
 			"mobgroup":  # Add support for mobgroup
-				properties["texture"] = Gamedata.mods.get_content_by_id(DMod.ContentType.MOBGROUPS,entity["id"]).sprite
+				properties["texture"] = (
+					Gamedata.mods.get_content_by_id(DMod.ContentType.MOBGROUPS, entity["id"]).sprite
+				)
 			_:
 				continue  # Skip unsupported entity types
 
@@ -419,36 +445,37 @@ func add_brushes_from_area(entity_list: Array, entity_type: String = "entity"):
 func _on_area_editor_area_selected_ok(areas_clone: Array):
 	set_area_data(areas_clone)
 
+
 # Provide an array of area objects and it will be loaded into the brushcomposer
 func set_area_data(areas_clone: Array):
 	# Remember the selected area ID from the areas_option_button.
 	var selected_area_id = get_selected_area_name()
-	
+
 	# Update the map areas in gridContainer with the areas_clone data.
 	gridContainer.update_map_areas(areas_clone)
-	
+
 	# Clear the current items in the areas_option_button.
 	areas_option_button.clear()
-	
+
 	# Add the "None" option as the first item.
 	areas_option_button.add_item("None")
-	
+
 	# Get the list of all area IDs from the areas_clone list.
 	var area_ids = areas_clone.map(func(area): return area["id"])
-	
+
 	# Add each area ID to the areas_option_button.
 	for area_id in area_ids:
 		areas_option_button.add_item(area_id)
-	
+
 	# Re-select the previously selected area if it's still present.
 	if selected_area_id in area_ids:
 		for i in range(areas_option_button.get_item_count()):
 			if areas_option_button.get_item_text(i) == selected_area_id:
 				areas_option_button.select(i)
-				
+
 				# Collect data for the selected area from areas_clone.
 				var area_data = areas_clone.filter(func(area): return area["id"] == selected_area_id)[0]
-				
+
 				# Check the area_data["rotate_random"] property and set the rotation button accordingly.
 				rotation_button.button_pressed = area_data["rotate_random"]
 				break
@@ -456,7 +483,7 @@ func set_area_data(areas_clone: Array):
 		# If the previously selected area is not present, select "None".
 		areas_option_button.select(0)
 		clear_brush_container()
-		
+
 	# Refresh the brush container based on the selected area
 	refresh_brush_container_from_selected_area()
 
@@ -473,4 +500,9 @@ func _on_null_tile_button_up():
 
 # Function to be called when the npc tile button is pressed
 func _on_npc_tile_button_up():
-	print_debug("This function needs further implementation")
+	var npc_tile_properties = {
+		"texture": load("res://Scenes/ContentManager/Mapeditor/Images/nulltile_32.png"),
+		"entityID": "npc_tile",
+		"entityType": "npc_tile",
+	}
+	add_tilebrush_to_container_with_properties(npc_tile_properties)


### PR DESCRIPTION
## Summary
- add npc tile button to map editor brush composer so npc placeholders can be painted
- mark npc tile brush composer tasks as complete

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_68934a866fa483258be6c2f1bbaefafa