### PR TITLE
feat: add item categories and prototypes

### DIFF
--- a/.project-management/current-prd/tasks-prd-add-new-items.md
+++ b/.project-management/current-prd/tasks-prd-add-new-items.md
@@ -57,11 +57,11 @@
 
 ## Tasks
 
-- [ ] 2.0 Design two new items for each category (urban, nature, industrial, medical, survival)
-- [ ] 2.1 Urban: draft two distinct item concepts with names, descriptions, basic stats (weight, value, durability), and urban-specific properties.
-- [ ] 2.2 Nature: draft two items with the above base stats plus nature-specific properties.
-- [ ] 2.3 Industrial: draft two items with base stats plus industrial-specific properties.
-- [ ] 2.4 Medical: draft two medical items, ensuring relevant properties (e.g., healing amount, dosage).
-- [ ] 2.5 Survival: draft two survival items with properties such as durability or environmental resistance.
-- [ ] 2.6 Assign the placeholder sprite `9mm.png` to each item.
+- [x] 2.0 Design two new items for each category (urban, nature, industrial, medical, survival)
+- [x] 2.1 Urban: draft two distinct item concepts with names, descriptions, basic stats (weight, value, durability), and urban-specific properties.
+- [x] 2.2 Nature: draft two items with the above base stats plus nature-specific properties.
+- [x] 2.3 Industrial: draft two items with base stats plus industrial-specific properties.
+- [x] 2.4 Medical: draft two medical items, ensuring relevant properties (e.g., healing amount, dosage).
+- [x] 2.5 Survival: draft two survival items with properties such as durability or environmental resistance.
+- [x] 2.6 Assign the placeholder sprite `9mm.png` to each item.
 *End of document*

--- a/Mods/Dimensionfall/Items/Items.json
+++ b/Mods/Dimensionfall/Items/Items.json
@@ -3065,5 +3065,177 @@
 		"two_handed": false,
 		"volume": 30.0,
 		"weight": 2.0
+	},
+	{
+		"Urban": {
+			"lockpick_bonus": 10
+		},
+		"description": "A compact kit of lockpicks useful for opening simple locks.",
+		"id": "lockpick_set",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Lockpick Set",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 5.0,
+		"weight": 0.2,
+		"value": 25.0,
+		"durability": 40.0
+	},
+	{
+		"Urban": {
+			"navigation_bonus": 5
+		},
+		"description": "A worn map showing major roads and alleyways of the city.",
+		"id": "street_map",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Street Map",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 2.0,
+		"weight": 0.1,
+		"value": 10.0,
+		"durability": 30.0
+	},
+	{
+		"Nature": {
+			"stealth_bonus": 15
+		},
+		"description": "A cloak patterned to blend with forest environments.",
+		"id": "camouflage_cloak",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Camouflage Cloak",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 60.0,
+		"weight": 1.5,
+		"value": 40.0,
+		"durability": 80.0
+	},
+	{
+		"Nature": {
+			"forage_bonus": 20
+		},
+		"description": "Tools for gathering edible plants and mushrooms safely.",
+		"id": "foraging_kit",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Foraging Kit",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 50.0,
+		"weight": 1.0,
+		"value": 35.0,
+		"durability": 60.0
+	},
+	{
+		"Industrial": {
+			"heat_output": 100
+		},
+		"description": "Portable torch for cutting or welding metal.",
+		"id": "welding_torch",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Welding Torch",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": true,
+		"volume": 100.0,
+		"weight": 3.0,
+		"value": 80.0,
+		"durability": 120.0
+	},
+	{
+		"Industrial": {
+			"repair_bonus": 15
+		},
+		"description": "Spare components and tools for electronics repair.",
+		"id": "circuit_repair_kit",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Circuit Repair Kit",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 40.0,
+		"weight": 1.2,
+		"value": 70.0,
+		"durability": 50.0
+	},
+	{
+		"Medical": {
+			"healing": 15,
+			"dosage": 3
+		},
+		"description": "Disinfectant spray that cleans wounds quickly.",
+		"id": "antiseptic_spray",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Antiseptic Spray",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 10.0,
+		"weight": 0.3,
+		"value": 30.0,
+		"durability": 20.0
+	},
+	{
+		"Medical": {
+			"healing": 25,
+			"dosage": 1
+		},
+		"description": "Compact kit for stitching deep wounds.",
+		"id": "suture_kit",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Suture Kit",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 15.0,
+		"weight": 0.4,
+		"value": 45.0,
+		"durability": 25.0
+	},
+	{
+		"Survival": {
+			"warmth": 40
+		},
+		"description": "Lightweight reflective blanket that retains body heat.",
+		"id": "thermal_blanket",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Thermal Blanket",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 20.0,
+		"weight": 0.5,
+		"value": 20.0,
+		"durability": 50.0
+	},
+	{
+		"Survival": {
+			"purification_rate": 0.9
+		},
+		"description": "Handheld purifier for filtering contaminants from water.",
+		"id": "water_filter",
+		"image": "./Mods/Dimensionfall/Items/9mm.png",
+		"max_stack_size": 1,
+		"name": "Water Filter",
+		"sprite": "9mm.png",
+		"stack_size": 1,
+		"two_handed": false,
+		"volume": 25.0,
+		"weight": 0.7,
+		"value": 60.0,
+		"durability": 80.0
 	}
 ]


### PR DESCRIPTION
## Summary
- add placeholder items for Urban, Nature, Industrial, Medical, and Survival categories
- track completion of add-new-items tasks

## Testing
- `godot --headless --import` *(fails: Unrecognized UID)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: GutUtils not declared and missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_689350a4916083258ea30c7e3b0952f4