### PR TITLE
Handle npc_tile in map processing with tests

### DIFF
--- a/.project-management/current-prd/tasks-prd-npc_tile.md
+++ b/.project-management/current-prd/tasks-prd-npc_tile.md
@@ -55,12 +55,12 @@
 - [x] 2.0 Implement painting logic that places `npc_tile` with rotation and replaces existing `mob`, `mobgroup`, `furniture`, or `itemgroup` features (`Scenes/ContentManager/Mapeditor/Scripts/GridContainer.gd`).
   - [x] 2.1 Extend painting function to recognize `npc_tile` selection and capture rotation data.
   - [x] 2.2 Implement feature-replacement logic so `npc_tile` overwrites `mob`, `mobgroup`, `furniture`, or `itemgroup` on the same tile.
-- [ ] 4.0 Handle `npc_tile` entries during map processing, logging their presence and allowing later features to overwrite them (`Scripts/Helper/map_manager.gd`).
-  - [ ] 4.1 Extend map processing loop to detect `npc_tile` entries and log them for debugging.
-- [ ] 5.0 Add tests covering brush placement, serialization/deserialization, and map processing of `npc_tile` entries (`Tests/Unit/`).
+- [x] 4.0 Handle `npc_tile` entries during map processing, logging their presence and allowing later features to overwrite them (`Scripts/Helper/map_manager.gd`).
+  - [x] 4.1 Extend map processing loop to detect `npc_tile` entries and log them for debugging.
+- [x] 5.0 Add tests covering brush placement, serialization/deserialization, and map processing of `npc_tile` entries (`Tests/Unit/`).
   - [x] 5.1 Write unit tests for brush placement and rotation handling in `GridContainer.gd`.
-  - [ ] 5.2 Write serialization/deserialization tests ensuring `npc_tile` data persists accurately.
-  - [ ] 5.3 Add tests for map processing logic confirming correct overwrite behavior and logging.
-  - [ ] 5.4 Run all existing test suites to ensure no regressions.
+  - [x] 5.2 Write serialization/deserialization tests ensuring `npc_tile` data persists accurately.
+  - [x] 5.3 Add tests for map processing logic confirming correct overwrite behavior and logging.
+  - [x] 5.4 Run all existing test suites to ensure no regressions.
 
 *End of document*

--- a/Scripts/Helper/map_manager.gd
+++ b/Scripts/Helper/map_manager.gd
@@ -10,6 +10,9 @@ extends Node
 # The level generator will register itself to this variable when it's ready
 var level_generator: Node = null
 
+# Stores `npc_tile` entries encountered during map processing for debugging
+var npc_tile_log: Array = []
+
 
 func get_chunk_from_position(position_in_3d_space: Vector3) -> Chunk:
 	return level_generator.get_chunk_from_position(position_in_3d_space)
@@ -417,6 +420,9 @@ func apply_area_clusters_to_tiles(
 		# Example tile: {"id":"road_asphalt_basic","areas":[{"id":"cars","rotation":270}]}
 		# Example picked_tile: {"id": "forest_underbrush_04", "count": 100}
 		for tile: Dictionary in cluster:
+			# Log `npc_tile` entries for debugging purposes
+			if tile.has("feature") and tile["feature"].get("type", "") == "npc_tile":
+				npc_tile_log.append(tile["feature"].duplicate())
 			var processed_data = process_area_data(area_data, tile, picked_tile)
 
 			# Remove existing entities if new entities are present in processed data

--- a/Tests/Unit/dmap_npc_tile_test.gd
+++ b/Tests/Unit/dmap_npc_tile_test.gd
@@ -1,0 +1,15 @@
+extends GutTest
+
+
+# Tests serialization and deserialization of tiles with `npc_tile` features
+func test_npc_tile_serialization_roundtrip():
+	var DMap = load("res://Scripts/Gamedata/DMap.gd")
+	var map = DMap.new("test_map", "", null)
+	var tile = {"id": "grass", "rotation": 0, "feature": {"type": "npc_tile", "rotation": 180}}
+	map.levels[0] = [tile]
+	var data = map.get_data()
+	var map_loaded = DMap.new("test_map", "", null)
+	map_loaded.set_data(data)
+	var result = map_loaded.levels[0][0]
+	assert_eq(result.feature.type, "npc_tile", "Expected npc_tile feature type")
+	assert_eq(result.feature.rotation, 180, "Expected rotation 180")

--- a/Tests/Unit/dmap_npc_tile_test.gd.uid
+++ b/Tests/Unit/dmap_npc_tile_test.gd.uid
@@ -1,0 +1,1 @@
+uid://gltt251cjm28

--- a/Tests/Unit/map_manager_npc_tile_test.gd
+++ b/Tests/Unit/map_manager_npc_tile_test.gd
@@ -1,0 +1,29 @@
+extends GutTest
+
+
+# Tests map_manager logging and overwriting of `npc_tile` features
+func test_npc_tile_logged_and_overwritten():
+	var MapManager = load("res://Scripts/Helper/map_manager.gd")
+	var manager = MapManager.new()
+	var tile = {
+		"id": "base", "areas": [{"id": "area"}], "feature": {"type": "npc_tile", "rotation": 0}
+	}
+	var level = [tile]
+	var map_data = {
+		"areas":
+		[
+			{
+				"id": "area",
+				"tiles": [{"id": "base", "count": 1}],
+				"entities": [{"id": "Tree_00", "type": "furniture", "count": 1}],
+				"spawn_chance": 100,
+				"rotate_random": false
+			}
+		],
+		"levels": [level]
+	}
+	manager.npc_tile_log.clear()
+	manager.apply_area_clusters_to_tiles(level, "area", map_data, 1, 1)
+	assert_eq(manager.npc_tile_log.size(), 1, "Expected one npc_tile logged")
+	var result_tile = level[0]
+	assert_eq(result_tile.feature.type, "furniture", "npc_tile should be overwritten")

--- a/Tests/Unit/map_manager_npc_tile_test.gd.uid
+++ b/Tests/Unit/map_manager_npc_tile_test.gd.uid
@@ -1,0 +1,1 @@
+uid://be3jbstj8blca


### PR DESCRIPTION
## Summary
- log `npc_tile` entries during map processing
- cover `npc_tile` serialization and map processing with unit tests
- update task list for completed `npc_tile` work

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_6894963b75788325abebe9a2c13fd2a8