### PR TITLE
fix: rename state transition signal

### DIFF
--- a/.project-management/current-prd/tasks-prd-bug-logic-error-identification.md
+++ b/.project-management/current-prd/tasks-prd-bug-logic-error-identification.md
@@ -27,7 +27,13 @@
 
 ### Existing Files Modified
 - `Scripts/Mob/state.gd` - Rename `Transistioned` signal for clarity.
-- `Scripts/Mob/MobRangedAttack.gd` - Replace hard‑coded values with mob data properties.
+- `Scripts/Mob/StateMachine.gd` - Connect to renamed `Transitioned` signal.
+- `Scripts/Mob/MobAttack.gd` - Emit `Transitioned` for state changes.
+- `Scripts/Mob/MobIdle.gd` - Emit `Transitioned` for state changes.
+- `Scripts/Mob/MobRangedAttack.gd` - Emit `Transitioned` for state changes.
+- `Scripts/Mob/MobFollow.gd` - Emit `Transitioned` for state changes.
+- `Tests/Unit/test_mob.gd` - Update test for `Transitioned` signal.
+- `Tests/Unit/test_player.gd` - Update test for `Transitioned` signal.
 
 ### Files To Remove
 - None
@@ -36,9 +42,9 @@
 - Unit tests should typically be placed in `/Tests/Unit/`.
 
 ## Tasks
-- [ ] 1.0 Fix misnamed mob state transition signal
-  - [ ] 1.1 In `Scripts/Mob/state.gd`, rename the `Transistioned` signal to `Transitioned`.
-  - [ ] 1.2 Update all references to the old signal name across the codebase.
-  - [ ] 1.3 Add unit tests (`Tests/Unit/test_state_transitions.gd`) verifying that `Transitioned` fires correctly when state changes occur.
+- [x] 1.0 Fix misnamed mob state transition signal
+  - [x] 1.1 In `Scripts/Mob/state.gd`, rename the `Transistioned` signal to `Transitioned`.
+  - [x] 1.2 Update all references to the old signal name across the codebase.
+  - [x] 1.3 Add unit tests (`Tests/Unit/test_state_transitions.gd`) verifying that `Transitioned` fires correctly when state changes occur.
 
 *End of document*

--- a/Scripts/Mob/MobAttack.gd
+++ b/Scripts/Mob/MobAttack.gd
@@ -2,10 +2,11 @@ extends State
 class_name MobAttack
 
 var attack_timer: Timer
-var mob: CharacterBody3D # The mob that we execute the attack for
+var mob: CharacterBody3D  # The mob that we execute the attack for
 
-var spotted_target: CharacterBody3D # This mob's current target for combat
+var spotted_target: CharacterBody3D  # This mob's current target for combat
 var is_in_attack_mode = false
+
 
 func _ready():
 	name = "MobAttack"
@@ -32,7 +33,7 @@ func exit():
 
 func physics_update(_delta: float):
 	if mob.terminated:
-		Transistioned.emit(self, "mobterminate") 
+		Transitioned.emit(self, "mobterminate")
 	# Rotation towards target using look_at
 	if spotted_target:
 		var target_position = spotted_target.global_position
@@ -40,16 +41,22 @@ func physics_update(_delta: float):
 		mob.meshInstance.look_at(target_position, Vector3.UP)
 
 	var space_state = get_world_3d().direct_space_state
-	var query = PhysicsRayQueryParameters3D.create(mob.global_position, spotted_target.global_position, 3, [self])
+	var query = PhysicsRayQueryParameters3D.create(
+		mob.global_position, spotted_target.global_position, 3, [self]
+	)
 	var result = space_state.intersect_ray(query)
 
 	if result and result.collider:
-
-		if (result.collider.is_in_group("Players") or result.collider.is_in_group("mobs")) and Vector3(mob.global_position).distance_to(spotted_target.global_position) <= mob.get_melee_range():
-
+		if (
+			(result.collider.is_in_group("Players") or result.collider.is_in_group("mobs"))
+			and (
+				Vector3(mob.global_position).distance_to(spotted_target.global_position)
+				<= mob.get_melee_range()
+			)
+		):
 			if !is_in_attack_mode:
 				is_in_attack_mode = true
-				try_to_attack()         
+				try_to_attack()
 		else:
 			is_in_attack_mode = false
 			stop_attacking()
@@ -76,8 +83,9 @@ func attack():
 	# Exmple: {"id": "basic_melee", "damage_multiplier": 1, "type": "melee"}
 	var chosen_attack: Dictionary = mob.get_attack_of_type("melee")
 	if not chosen_attack:
-		chosen_attack =  {}
+		chosen_attack = {}
 	_apply_attack_to_entity(chosen_attack)
+
 
 # Helper function to send attack data to the entity's get_hit method
 func _apply_attack_to_entity(chosen_attack: Dictionary) -> void:
@@ -85,7 +93,7 @@ func _apply_attack_to_entity(chosen_attack: Dictionary) -> void:
 		var attack_data: Dictionary = {
 			"attack": chosen_attack,
 			"mobposition": mob.global_position,
-			"hit_chance": 100, # Only used when attacking another mob, not the player
+			"hit_chance": 100,  # Only used when attacking another mob, not the player
 			"source": mob
 		}
 		spotted_target.get_hit(attack_data)
@@ -94,11 +102,11 @@ func _apply_attack_to_entity(chosen_attack: Dictionary) -> void:
 func stop_attacking():
 	print("I stopped attacking")
 	attack_timer.stop()
-	Transistioned.emit(self, "mobfollow")
+	Transitioned.emit(self, "mobfollow")
 
 
 func _on_detection_target_spotted(entity):
-	spotted_target = entity # Replace with function body.
+	spotted_target = entity  # Replace with function body.
 
 
 func _on_attack_cooldown_timeout():

--- a/Scripts/Mob/MobFollow.gd
+++ b/Scripts/Mob/MobFollow.gd
@@ -1,19 +1,17 @@
 extends State
 class_name MobFollow
 
-
-
-var nav_agent: NavigationAgent3D # Used for pathfinding
-var mob: CharacterBody3D # The mob that we are enabling the follow behaviour for
-var mobCol: CollisionShape3D # The collision shape of the mob
+var nav_agent: NavigationAgent3D  # Used for pathfinding
+var mob: CharacterBody3D  # The mob that we are enabling the follow behaviour for
+var mobCol: CollisionShape3D  # The collision shape of the mob
 var pathfinding_timer: Timer
-var spotted_target: CharacterBody3D # This mob's current target for combat
+var spotted_target: CharacterBody3D  # This mob's current target for combat
 # Variables for dash state and timer
-var dash_timer: Timer = Timer.new()           # Timer for cooldown after a dash
-var is_dashing: bool = false                  # Flag to check if currently dashing
-
+var dash_timer: Timer = Timer.new()  # Timer for cooldown after a dash
+var is_dashing: bool = false  # Flag to check if currently dashing
 
 @onready var target_location = mob.position
+
 
 # Initializes the MobFollow state by setting up references to mob components
 # (collision shape, navigation agent) and configuring the pathfinding timer.
@@ -28,7 +26,7 @@ func _ready():
 	pathfinding_timer = follow_timer
 	add_child.call_deferred(follow_timer)
 	pathfinding_timer.timeout.connect(_on_timer_timeout)
-	
+
 	# Set up the dash cooldown timer
 	dash_timer.one_shot = true
 	add_child.call_deferred(dash_timer)
@@ -38,7 +36,7 @@ func _ready():
 	Helper.signal_broker.mob_killed.connect(_on_mob_killed)
 
 
-# Called when the mob enters the follow state. Starts the pathfinding timer 
+# Called when the mob enters the follow state. Starts the pathfinding timer
 # and initiates path creation towards the target location.
 func enter():
 	print("Following the target")
@@ -57,9 +55,9 @@ func exit():
 # transitioning to an attack state if within melee range.
 func physics_update(_delta: float):
 	if mob.terminated:
-		Transistioned.emit(self, "mobterminate")
+		Transitioned.emit(self, "mobterminate")
 		return
-	
+
 	move_toward_target()
 	orient_toward_target()
 	check_for_target_in_range()
@@ -73,11 +71,15 @@ func move_toward_target():
 		var current_chunk = mob.get_chunk_from_position(target_location)
 		mob.update_navigation_agent_map(current_chunk)
 		return
-	
+
 	var dir = mob.to_local(next_pos).normalized()
-	
+
 	# Apply dash speed if dash is active
-	var move_speed = mob.current_move_speed * mob.dash["speed_multiplier"] if is_dashing else mob.current_move_speed
+	var move_speed = (
+		mob.current_move_speed * mob.dash["speed_multiplier"]
+		if is_dashing
+		else mob.current_move_speed
+	)
 	mob.velocity = dir * move_speed
 	mob.move_and_slide()
 
@@ -94,13 +96,13 @@ func orient_toward_target():
 func check_for_target_in_range():
 	if not spotted_target:
 		return
-	
+
 	var space_state = get_world_3d().direct_space_state
 	var query = PhysicsRayQueryParameters3D.create(
 		mobCol.global_position,
 		spotted_target.global_position,
-		(1 << 0) | (1 << 1) | (1 << 2), # Layer mask for layers 1 (player), 2 (mobs), and 3 (walls)
-		[self] # Exclude self
+		(1 << 0) | (1 << 1) | (1 << 2),  # Layer mask for layers 1 (player), 2 (mobs), and 3 (walls)
+		[self]  # Exclude self
 	)
 	var result = space_state.intersect_ray(query)
 
@@ -111,24 +113,26 @@ func check_for_target_in_range():
 			return
 
 		# If the ray hits a valid target before hitting a wall, continue checking attack range
-		var is_valid_target = result.collider.is_in_group("Players") or result.collider.is_in_group("mobs")
+		var is_valid_target = (
+			result.collider.is_in_group("Players") or result.collider.is_in_group("mobs")
+		)
 		var distance_to_target = mobCol.global_position.distance_to(spotted_target.global_position)
 
 		if is_valid_target:
 			if mob.attacks.has("ranged") and mob.attacks.ranged.size() > 0:
 				if distance_to_target <= mob.get_ranged_range():
 					print("Changing state to mobrangedattack...")
-					Transistioned.emit(self, "mobrangedattack")
+					Transitioned.emit(self, "mobrangedattack")
 			else:
 				if distance_to_target <= mob.get_melee_range() / 2:
 					print("Changing state to mobattack...")
-					Transistioned.emit(self, "mobattack")
+					Transitioned.emit(self, "mobattack")
 
 
 # Checks if the mob has reached its target location, transitions to idle if true
 func check_if_idle():
 	if Vector3(mob.global_position).distance_to(target_location) <= 0.5:
-		Transistioned.emit(self, "mobidle")
+		Transitioned.emit(self, "mobidle")
 
 
 # Sets the target position for the navigation agent based on target location.

--- a/Scripts/Mob/MobIdle.gd
+++ b/Scripts/Mob/MobIdle.gd
@@ -3,8 +3,8 @@ class_name MobIdle
 
 var idle_speed
 
-var nav_agent: NavigationAgent3D # Used for pathfinding
-var mob: CharacterBody3D # The mob we provide idle behavour for
+var nav_agent: NavigationAgent3D  # Used for pathfinding
+var mob: CharacterBody3D  # The mob we provide idle behavour for
 var move_distance: float = 15.0
 var moving_timer: Timer
 
@@ -13,6 +13,7 @@ var moving_timer: Timer
 var is_looking_to_move = false
 
 var rng = RandomNumberGenerator.new()
+
 
 func _ready():
 	name = "MobIdle"
@@ -37,20 +38,22 @@ func exit():
 
 func physics_update(_delta: float):
 	if mob.terminated:
-		Transistioned.emit(self, "mobterminate")
-	
+		Transitioned.emit(self, "mobterminate")
+
 	if is_looking_to_move:
 		handle_mob_movement()
 
+
 func handle_mob_movement():
 	var chunk_position = mob.get_chunk_from_position(target_location)
-	
+
 	# Check if the target location has a navigation map
 	if Helper.chunk_navigation_maps.has(chunk_position):
-		move_mob_to_target() # Continue moving
+		move_mob_to_target()  # Continue moving
 	else:
 		# If there's no navigation map for the target location, stop moving
 		is_looking_to_move = false
+
 
 func move_mob_to_target():
 	var dir: Vector3
@@ -60,13 +63,13 @@ func move_mob_to_target():
 		dir = mob.to_local(nav_agent.get_next_path_position()).normalized()
 	mob.velocity = dir * mob.current_idle_move_speed
 	mob.move_and_slide()
-	
+
 	if Vector3(mob.global_position).distance_to(target_location) <= 0.5:
 		is_looking_to_move = false
 
 
 func _on_detection_target_spotted(_entity):
-	Transistioned.emit(self, "mobfollow")
+	Transitioned.emit(self, "mobfollow")
 
 
 func makepath() -> void:
@@ -76,9 +79,14 @@ func makepath() -> void:
 
 func _on_moving_cooldown_timeout():
 	var space_state = get_world_3d().direct_space_state
-	var random_dir = Vector3(rng.randf_range(-1,1), 0.0, rng.randf_range(-1, 1))
+	var random_dir = Vector3(rng.randf_range(-1, 1), 0.0, rng.randf_range(-1, 1))
 	# Keep movement on the horizontal plane to ensure the target is on the navigation mesh.
-	var query = PhysicsRayQueryParameters3D.create(mob.global_position, mob.global_position + (random_dir * move_distance), int(pow(2, 1-1) + pow(2, 3-1)),[self])
+	var query = PhysicsRayQueryParameters3D.create(
+		mob.global_position,
+		mob.global_position + (random_dir * move_distance),
+		int(pow(2, 1 - 1) + pow(2, 3 - 1)),
+		[self]
+	)
 
 	var result = space_state.intersect_ray(query)
 	if !result:

--- a/Scripts/Mob/MobRangedAttack.gd
+++ b/Scripts/Mob/MobRangedAttack.gd
@@ -5,46 +5,57 @@ var attack_timer: Timer
 var mob: CharacterBody3D
 var spotted_target: CharacterBody3D
 
+
 func _ready():
 	name = "MobRangedAttack"
 	attack_timer = Timer.new()
-	attack_timer.wait_time = 1 #mob.rmob.ranged_cooldown # TODO: Need a ranged_cooldown in mob data
+	attack_timer.wait_time = 1  #mob.rmob.ranged_cooldown # TODO: Need a ranged_cooldown in mob data
 	add_child.call_deferred(attack_timer)
 	attack_timer.timeout.connect(_on_attack_cooldown_timeout)
+
 
 func enter():
 	attack_timer.start()
 	print("ENTERING RANGED ATTACK MODE")
 
+
 func exit():
 	attack_timer.stop()
 
+
 func physics_update(_delta: float):
 	if mob.terminated:
-		Transistioned.emit(self, "mobterminate")
+		Transitioned.emit(self, "mobterminate")
 		return
 
 	var ranged_range: int = mob.get_ranged_range()
 
-	if spotted_target and is_instance_valid(spotted_target) and mob.global_position.distance_to(spotted_target.global_position) <= ranged_range:
+	if (
+		spotted_target
+		and is_instance_valid(spotted_target)
+		and mob.global_position.distance_to(spotted_target.global_position) <= ranged_range
+	):
 		# Make the mob look at the target
 		var target_position = spotted_target.global_position
-		target_position.y = mob.meshInstance.global_position.y # Align y to avoid tilting
+		target_position.y = mob.meshInstance.global_position.y  # Align y to avoid tilting
 		mob.meshInstance.look_at(target_position, Vector3.UP)
 
 		var space_state = get_world_3d().direct_space_state
-		var query = PhysicsRayQueryParameters3D.create(mob.global_position, spotted_target.global_position, 3, [self])
+		var query = PhysicsRayQueryParameters3D.create(
+			mob.global_position, spotted_target.global_position, 3, [self]
+		)
 		var result = space_state.intersect_ray(query)
 
 		if result and result.collider == spotted_target:
 			if attack_timer.is_stopped():
 				attack_timer.start()
 	else:
-		Transistioned.emit(self, "mobfollow") # Exit back to follow state if out of range
+		Transitioned.emit(self, "mobfollow")  # Exit back to follow state if out of range
 
 
 func _on_attack_cooldown_timeout():
 	shoot_projectile()
+
 
 func shoot_projectile():
 	# Ensure target is still valid before shooting
@@ -53,7 +64,7 @@ func shoot_projectile():
 
 	var spawn_position = mob.global_transform.origin + Vector3(0.0, -0.0, 0.0)
 	var target_position = spotted_target.global_position
-	var projectile_speed: float = 5 # TODO: Read from RAttack.projectile_speed
+	var projectile_speed: float = 5  # TODO: Read from RAttack.projectile_speed
 
 	spawn_projectile(spawn_position, target_position, projectile_speed)
 
@@ -92,8 +103,5 @@ func create_attack_data(spawn_position: Vector3) -> Dictionary:
 	if not chosen_attack:
 		return {}
 	return {
-			"attack": chosen_attack,
-			"mobposition": spawn_position,
-			"hit_chance": 100,
-			"source": mob
-		}
+		"attack": chosen_attack, "mobposition": spawn_position, "hit_chance": 100, "source": mob
+	}

--- a/Scripts/Mob/StateMachine.gd
+++ b/Scripts/Mob/StateMachine.gd
@@ -26,9 +26,9 @@ func _ready():
 		var mob_attack = create_mob_attack()
 		states["mobattack"] = mob_attack
 
-		# Connect transitions
-		for state in states.values():
-			state.Transitioned.connect(on_child_transition)
+	# Connect transitions
+	for state in states.values():
+		state.Transitioned.connect(on_child_transition)
 
 	# Set the initial state if specified
 	if initial_state:

--- a/Scripts/Mob/StateMachine.gd
+++ b/Scripts/Mob/StateMachine.gd
@@ -4,7 +4,7 @@ extends Node
 var initial_state: State
 var current_state: State
 var states: Dictionary = {}
-var mob: CharacterBody3D # The mob that we are enabling the behaviour for
+var mob: CharacterBody3D  # The mob that we are enabling the behaviour for
 
 
 # Initialize the StateMachine
@@ -26,9 +26,9 @@ func _ready():
 		var mob_attack = create_mob_attack()
 		states["mobattack"] = mob_attack
 
-	# Connect transitions
-	for state in states.values():
-		state.Transistioned.connect(on_child_transition)
+		# Connect transitions
+		for state in states.values():
+			state.Transitioned.connect(on_child_transition)
 
 	# Set the initial state if specified
 	if initial_state:
@@ -51,13 +51,13 @@ func _physics_process(delta):
 func on_child_transition(state, new_state_name):
 	if state != current_state:
 		return
-		
+
 	var new_state = states.get(new_state_name.to_lower())
 	if !new_state:
 		return
 	if current_state:
 		current_state.exit()
-		
+
 	new_state.enter()
 	current_state = new_state
 
@@ -92,6 +92,7 @@ func create_mob_terminate() -> MobTerminate:
 	var mob_terminate = MobTerminate.new()
 	add_child.call_deferred(mob_terminate)
 	return mob_terminate
+
 
 # Create and configure MobRangedAttack
 func create_mob_ranged_attack() -> MobRangedAttack:

--- a/Scripts/Mob/state.gd
+++ b/Scripts/Mob/state.gd
@@ -3,7 +3,8 @@ extends Node3D
 class_name State
 
 @warning_ignore("unused_signal")
-signal Transistioned
+signal Transitioned
+
 
 func enter():
 	pass
@@ -15,6 +16,7 @@ func exit():
 
 func update(_delta: float):
 	pass
+
 
 func physics_update(_delta: float):
 	pass

--- a/Tests/Unit/test_mob.gd
+++ b/Tests/Unit/test_mob.gd
@@ -10,11 +10,13 @@ var mock_level_manager: Node3D
 var mock_level_generator: Node3D
 var mock_target_manager: Node3D
 
+
 # Runs before all tests.
 func before_all():
 	var custom_mods: Array[DMod] = [Gamedata.mods.by_id("Core"), Gamedata.mods.by_id("Test")]
 	Runtimedata.reconstruct(custom_mods)
 	await get_tree().process_frame
+
 
 # Runs before each test.
 func before_each():
@@ -23,14 +25,15 @@ func before_each():
 	mock_level_generator = Node3D.new()
 	const TargetManager = preload("res://Scripts/target_manager.gd")
 	mock_target_manager = TargetManager.new()
-	
+
 	add_child(mock_target_manager)
 	test_chunk.level_manager = mock_level_manager
 	test_chunk.level_generator = mock_level_generator
 	add_child(mock_level_manager)
 	add_child(mock_level_generator)
 
-	test_chunk.mypos = Vector3(32, 0, 64) # Example position (chunk (1, 2) with 32x32 blocks)
+	test_chunk.mypos = Vector3(32, 0, 64)  # Example position (chunk (1, 2) with 32x32 blocks)
+
 
 # Runs after each test.
 func after_each():
@@ -38,21 +41,25 @@ func after_each():
 	# Awaiting the `chunk_unloaded` signal will produce an error in GUT somehow, so don't do that
 	test_chunk.unload_chunk()
 	# Verify that the load state is `UNLOADING`)
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.UNLOADING, "Chunk load_state should be UNLOADING.")
-	var chunk_is_unloaded = func():
-		return test_chunk == null
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.UNLOADING, "Chunk load_state should be UNLOADING."
+	)
+	var chunk_is_unloaded = func(): return test_chunk == null
 	# Calls chunk_is_unloaded every second until it returns true and asserts on the returned value
-	assert_true(await wait_until(chunk_is_unloaded, 10, 1),"Chunk should be unloaded in 10 seconds")
+	assert_true(
+		await wait_until(chunk_is_unloaded, 10, 1), "Chunk should be unloaded in 10 seconds"
+	)
 
-	var mobs: Array = get_tree().get_nodes_in_group("mobs") 
-	assert_eq(mobs.size(),0,"too many mobs")
-	
+	var mobs: Array = get_tree().get_nodes_in_group("mobs")
+	assert_eq(mobs.size(), 0, "too many mobs")
+
 	if test_chunk and is_instance_valid(test_chunk):
 		test_chunk.queue_free()
 	if mock_level_manager:
 		mock_level_manager.queue_free()
 	if mock_level_generator:
 		mock_level_generator.queue_free()
+
 
 # Runs after all tests.
 func after_all():
@@ -61,44 +68,59 @@ func after_all():
 
 # Test if the chunk initializes and spawns and moves correctly.
 func test_mob_spawn():
-	test_chunk.chunk_data = {
-		"id": "basic_mob_test_map",
-		"rotation": 0
-	}
+	test_chunk.chunk_data = {"id": "basic_mob_test_map", "rotation": 0}
 
 	add_child(test_chunk)
 
 	await get_tree().process_frame
 	# Test if chunk state is set correctly
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state.")
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state."
+	)
 
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
 
 	# Verify the state reset after generation
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.NEITHER, "Chunk should have reset to NEITHER state after generation.")
-	
-	var mobs: Array = get_tree().get_nodes_in_group("mobs") 
-	assert_eq(mobs.size(),1,"too many or not enough mobs")
+	assert_eq(
+		test_chunk.load_state,
+		Chunk.LoadStates.NEITHER,
+		"Chunk should have reset to NEITHER state after generation."
+	)
+
+	var mobs: Array = get_tree().get_nodes_in_group("mobs")
+	assert_eq(mobs.size(), 1, "too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
-	assert_eq(first_mob.rmob.id,"generic_test_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mob_position,Vector3(47.5,1.5,79.5),"Mob spawned somewhere else")
-	
+	assert_eq(first_mob.rmob.id, "generic_test_mob", "A different mob spawned then expected")
+	assert_eq(first_mob.mob_position, Vector3(47.5, 1.5, 79.5), "Mob spawned somewhere else")
+
 	# Test that the mob is in idle state, since there is no target
 	var current_state: State = first_mob.get_current_state()
-	assert_is(current_state,MobIdle,"A different state then expected")
+	assert_is(current_state, MobIdle, "A different state then expected")
 	# Check that the mob has a NavigationAgent3D
 	assert_not_null(first_mob.nav_agent, "Mob's NavigationAgent3D is null.")
-	assert_true(first_mob.nav_agent is NavigationAgent3D, "Mob's nav_agent is not a NavigationAgent3D.")
+	assert_true(
+		first_mob.nav_agent is NavigationAgent3D, "Mob's nav_agent is not a NavigationAgent3D."
+	)
 
 	# Check that the MobIdle state has an associated Timer and it is running
 	var mob_idle: MobIdle = current_state as MobIdle
 	assert_not_null(mob_idle.moving_timer, "MobIdle moving_timer is null.")
-	assert_true(mob_idle.moving_timer.is_inside_tree(), "MobIdle moving_timer is not added to the tree.")
-	assert_true(mob_idle.moving_timer.is_stopped() == false, "MobIdle moving_timer is not running after entering the state.")
+	assert_true(
+		mob_idle.moving_timer.is_inside_tree(), "MobIdle moving_timer is not added to the tree."
+	)
+	assert_true(
+		mob_idle.moving_timer.is_stopped() == false,
+		"MobIdle moving_timer is not running after entering the state."
+	)
 
 	# Validate that the idle speed is set correctly from the mob
-	assert_eq(mob_idle.idle_speed, first_mob.idle_move_speed, "MobIdle idle_speed is not set correctly.")
+	assert_eq(
+		mob_idle.idle_speed, first_mob.idle_move_speed, "MobIdle idle_speed is not set correctly."
+	)
 
 	# Simulate the timer timeout and check if it attempts to move
 	mob_idle._on_moving_cooldown_timeout()
@@ -106,8 +128,13 @@ func test_mob_spawn():
 
 	# Verify that target_location is set and is_looking_to_move is true (assuming raycast is clear in your test setup)
 	assert_true(mob_idle.is_looking_to_move, "MobIdle did not start moving after cooldown timeout.")
-	assert_not_null(mob_idle.target_location, "MobIdle target_location is not set after cooldown timeout.")
-	assert_true(mob_idle.target_location != Vector3.ZERO, "MobIdle target_location is still Vector3.ZERO after cooldown timeout.")
+	assert_not_null(
+		mob_idle.target_location, "MobIdle target_location is not set after cooldown timeout."
+	)
+	assert_true(
+		mob_idle.target_location != Vector3.ZERO,
+		"MobIdle target_location is still Vector3.ZERO after cooldown timeout."
+	)
 
 	# Mock pathfinding and simulate movement handling
 	mob_idle.makepath()
@@ -118,11 +145,10 @@ func test_mob_spawn():
 
 	# Verify that velocity is being set when moving
 	assert_true(first_mob.velocity.length() > 0.0, "Mob is not moving during idle movement.")
-	
+
 	var initial_position = first_mob.last_position
-	var mob_has_moved = func():
-		return initial_position.distance_to(first_mob.last_position) > 0.01
-	assert_true(await wait_until(mob_has_moved, 10, 1),"Mob should have moved in 10 seconds")
+	var mob_has_moved = func(): return initial_position.distance_to(first_mob.last_position) > 0.01
+	assert_true(await wait_until(mob_has_moved, 10, 1), "Mob should have moved in 10 seconds")
 
 
 # Test that mobs of opposing factions engage in melee combat:
@@ -132,23 +158,23 @@ func test_mob_spawn():
 # - Attack and take damage
 # - Return to idle state after combat
 func test_mob_melee_combat():
-	test_chunk.chunk_data = {
-		"id": "melee_mob_combat_map",
-		"rotation": 0
-	}
+	test_chunk.chunk_data = {"id": "melee_mob_combat_map", "rotation": 0}
 	add_child(test_chunk)
 
 	await get_tree().process_frame
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
-	var mobs: Array = get_tree().get_nodes_in_group("mobs") 
-	assert_eq(mobs.size(),2,"too many or not enough mobs")
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
+	var mobs: Array = get_tree().get_nodes_in_group("mobs")
+	assert_eq(mobs.size(), 2, "too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
-	assert_eq(first_mob.rmob.id,"generic_test_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mob_position,Vector3(46.5,1.5,79.5),"Mob spawned somewhere else")
+	assert_eq(first_mob.rmob.id, "generic_test_mob", "A different mob spawned then expected")
+	assert_eq(first_mob.mob_position, Vector3(46.5, 1.5, 79.5), "Mob spawned somewhere else")
 	var second_mob: Mob = mobs[1]
-	assert_eq(second_mob.rmob.id,"generic_enemy_mob","A different mob spawned then expected")
+	assert_eq(second_mob.rmob.id, "generic_enemy_mob", "A different mob spawned then expected")
 	assert_eq(second_mob.mob_position, Vector3(49.5, 1.5, 79.5), "Mob spawned somewhere else")
 
 	# Test that the mobs are moving and getting closer
@@ -157,41 +183,53 @@ func test_mob_melee_combat():
 	var new_distance: float = first_mob.global_position.distance_to(second_mob.global_position)
 	assert_true(
 		new_distance < initial_distance,
-		"Mobs did not get closer to each other. Initial distance: %s, New distance: %s" % [initial_distance, new_distance]
+		(
+			"Mobs did not get closer to each other. Initial distance: %s, New distance: %s"
+			% [initial_distance, new_distance]
+		)
 	)
-	assert_true(first_mob.has_state("mobattack"),"Mob should have the mobattack state")
-	assert_true(second_mob.has_state("mobattack"),"Mob should have the mobattack state")
-	
+	assert_true(first_mob.has_state("mobattack"), "Mob should have the mobattack state")
+	assert_true(second_mob.has_state("mobattack"), "Mob should have the mobattack state")
+
 	# Test that the mob transitions into the mob attack state
 	await wait_frames(30)
 	var first_state: State = first_mob.get_current_state()
 	assert_not_null(first_state, "Mob has no state")
 	assert_is(first_state, MobFollow, "Mob should have MobFollow state")
-	assert_true(await wait_for_signal(first_state.Transistioned, 5), "Mob doesn't transition")
+	assert_true(await wait_for_signal(first_state.Transitioned, 5), "Mob doesn't transition")
 	first_state = first_mob.get_current_state()
-	assert_is(first_state,MobAttack,"A different state then expected")
-	
+	assert_is(first_state, MobAttack, "A different state then expected")
+
 	# Test that the second mob transitions into the MobAttack state
 	# Since we can't await two signals at once, we periodically try the state assert
 	var second_state: State = second_mob.get_current_state()
 	assert_not_null(second_state, "Second mob has no state")
-	var mob_has_transitioned = func():
-		return second_state is MobAttack
-	assert_true(await wait_until(mob_has_transitioned, 10, 1),"Mob should have transitioned")
+	var mob_has_transitioned = func(): return second_state is MobAttack
+	assert_true(await wait_until(mob_has_transitioned, 10, 1), "Mob should have transitioned")
 
 	# Test that the mobs attack eachother
 	var mob_taken_damage = func():
-		return first_mob.current_health < first_mob.health and second_mob.current_health < second_mob.health
-	assert_true(await wait_until(mob_taken_damage, 10, 1),"Mob should have taken damage")
-	
+		return (
+			first_mob.current_health < first_mob.health
+			and second_mob.current_health < second_mob.health
+		)
+	assert_true(await wait_until(mob_taken_damage, 10, 1), "Mob should have taken damage")
+
 	# Kill second_mob. Alternatively, wait for one to kill the other but that will take time
-	second_mob.get_hit({"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},"hit_chance":100})
-		
+	second_mob.get_hit(
+		{
+			"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},
+			"hit_chance": 100
+		}
+	)
+
 	# Wait for the second mob to be removed from the tree
 	var second_mob_removed = func():
 		var mobs_after_death: Array = get_tree().get_nodes_in_group("mobs")
 		return mobs_after_death.size() == 1
-	assert_true(await wait_until(second_mob_removed, 5, 1), "Second mob should be removed after death.")
+	assert_true(
+		await wait_until(second_mob_removed, 5, 1), "Second mob should be removed after death."
+	)
 
 	# Verify that only the first mob remains
 	var remaining_mobs: Array = get_tree().get_nodes_in_group("mobs")
@@ -199,9 +237,11 @@ func test_mob_melee_combat():
 	assert_eq(remaining_mobs[0], first_mob, "The remaining mob should be the first mob.")
 
 	# Verify that the first mob transitions back to MobIdle state
-	var first_mob_idle = func():
-		return first_mob.get_current_state() is MobIdle
-	assert_true(await wait_until(first_mob_idle, 5, 1), "First mob should transition back to MobIdle after the second mob dies.")
+	var first_mob_idle = func(): return first_mob.get_current_state() is MobIdle
+	assert_true(
+		await wait_until(first_mob_idle, 5, 1),
+		"First mob should transition back to MobIdle after the second mob dies."
+	)
 
 
 # Test if a ranged mob can hit a melee mob with an attack.
@@ -218,26 +258,26 @@ func test_mob_ranged_vs_melee():
 	entity_node.add_child(projectiles_container)
 	entity_node.projectiles_container = projectiles_container
 	add_child(entity_node)
-	
+
 	# initialize the chunk
-	test_chunk.chunk_data = {
-		"id": "melee_vs_ranged_mob_map",
-		"rotation": 0
-	}
+	test_chunk.chunk_data = {"id": "melee_vs_ranged_mob_map", "rotation": 0}
 	add_child(test_chunk)
 	await get_tree().process_frame
-	
+
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
 	# Verify that the mobs are spawned at the correct position and id
-	var mobs: Array = get_tree().get_nodes_in_group("mobs") 
-	assert_eq(mobs.size(),2,"too many or not enough mobs")
+	var mobs: Array = get_tree().get_nodes_in_group("mobs")
+	assert_eq(mobs.size(), 2, "too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
-	assert_eq(first_mob.rmob.id,"generic_ranged_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mob_position,Vector3(44.5,1.5,77.5),"Mob spawned somewhere else")
+	assert_eq(first_mob.rmob.id, "generic_ranged_mob", "A different mob spawned then expected")
+	assert_eq(first_mob.mob_position, Vector3(44.5, 1.5, 77.5), "Mob spawned somewhere else")
 	var second_mob: Mob = mobs[1]
-	assert_eq(second_mob.rmob.id,"generic_enemy_mob","A different mob spawned then expected")
+	assert_eq(second_mob.rmob.id, "generic_enemy_mob", "A different mob spawned then expected")
 	assert_eq(second_mob.mob_position, Vector3(49.5, 1.5, 79.5), "Mob spawned somewhere else")
 
 	# Test that the mobs are moving and getting closer
@@ -246,44 +286,54 @@ func test_mob_ranged_vs_melee():
 	var new_distance: float = first_mob.global_position.distance_to(second_mob.global_position)
 	assert_true(
 		new_distance < initial_distance,
-		"Mobs did not get closer to each other. Initial distance: %s, New distance: %s" % [initial_distance, new_distance]
+		(
+			"Mobs did not get closer to each other. Initial distance: %s, New distance: %s"
+			% [initial_distance, new_distance]
+		)
 	)
-	
+
 	# Test that the mob transitions into the mob ranged attack state
 	await wait_frames(30)
 	var first_state: State = first_mob.get_current_state()
 	assert_not_null(first_state, "Mob has no state")
-	assert_is(first_state,MobRangedAttack,"A different state then expected")
-	
+	assert_is(first_state, MobRangedAttack, "A different state then expected")
+
 	# Test that the second mob transitions into the MobFollow state
 	var second_state: State = second_mob.get_current_state()
 	assert_not_null(second_state, "Second mob has no state")
-	var mob_has_transitioned = func():
-		return second_state is MobFollow
-	assert_true(await wait_until(mob_has_transitioned, 10, 1),"Mob should have transitioned")
+	var mob_has_transitioned = func(): return second_state is MobFollow
+	assert_true(await wait_until(mob_has_transitioned, 10, 1), "Mob should have transitioned")
 
 	# Test that the first mob hits the second mob with it's projectile
-	var mob_taken_damage = func():
-		return second_mob.current_health < second_mob.health
-	assert_true(await wait_until(mob_taken_damage, 10, 1),"Mob should have taken damage")
-	
+	var mob_taken_damage = func(): return second_mob.current_health < second_mob.health
+	assert_true(await wait_until(mob_taken_damage, 10, 1), "Mob should have taken damage")
+
 	# Kill second_mob. Alternatively, wait for one to kill the other but that will take time
-	second_mob.get_hit({"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},"hit_chance":100})
-		
+	second_mob.get_hit(
+		{
+			"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},
+			"hit_chance": 100
+		}
+	)
+
 	# Wait for the second mob to be removed from the tree
 	var second_mob_removed = func():
 		var mobs_after_death: Array = get_tree().get_nodes_in_group("mobs")
 		return mobs_after_death.size() == 1
-	assert_true(await wait_until(second_mob_removed, 5, 1), "Second mob should be removed after death.")
+	assert_true(
+		await wait_until(second_mob_removed, 5, 1), "Second mob should be removed after death."
+	)
 
 	# Verify that only the first mob remains
 	var remaining_mobs: Array = get_tree().get_nodes_in_group("mobs")
 	assert_eq(remaining_mobs[0], first_mob, "The remaining mob should be the first mob.")
 
 	# Verify that the first mob transitions back to MobIdle state
-	var first_mob_idle = func():
-		return first_mob.get_current_state() is MobIdle
-	assert_true(await wait_until(first_mob_idle, 5, 1), "First mob should transition back to MobIdle after the second mob dies.")
+	var first_mob_idle = func(): return first_mob.get_current_state() is MobIdle
+	assert_true(
+		await wait_until(first_mob_idle, 5, 1),
+		"First mob should transition back to MobIdle after the second mob dies."
+	)
 	projectiles_container.free()
 	entity_node.free()
 
@@ -301,26 +351,26 @@ func test_mob_ranged_vs_furniture():
 	entity_node.add_child(projectiles_container)
 	entity_node.projectiles_container = projectiles_container
 	add_child(entity_node)
-	
+
 	# initialize the chunk
-	test_chunk.chunk_data = {
-		"id": "ranged_vs_furnture_map",
-		"rotation": 0
-	}
+	test_chunk.chunk_data = {"id": "ranged_vs_furnture_map", "rotation": 0}
 	add_child(test_chunk)
 	await get_tree().process_frame
-	
+
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
 	# Verify that the mobs are spawned at the correct position and id
-	var mobs: Array = get_tree().get_nodes_in_group("mobs") 
-	assert_eq(mobs.size(),2,"too many or not enough mobs")
+	var mobs: Array = get_tree().get_nodes_in_group("mobs")
+	assert_eq(mobs.size(), 2, "too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
-	assert_eq(first_mob.rmob.id,"generic_ranged_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mob_position,Vector3(44.5,1.5,77.5),"Mob spawned somewhere else")
+	assert_eq(first_mob.rmob.id, "generic_ranged_mob", "A different mob spawned then expected")
+	assert_eq(first_mob.mob_position, Vector3(44.5, 1.5, 77.5), "Mob spawned somewhere else")
 	var second_mob: Mob = mobs[1]
-	assert_eq(second_mob.rmob.id,"generic_enemy_mob","A different mob spawned then expected")
+	assert_eq(second_mob.rmob.id, "generic_enemy_mob", "A different mob spawned then expected")
 	assert_eq(second_mob.mob_position, Vector3(49.5, 1.5, 79.5), "Mob spawned somewhere else")
 
 	# Test that the mobs are moving and getting closer
@@ -329,27 +379,29 @@ func test_mob_ranged_vs_furniture():
 	var new_distance: float = first_mob.global_position.distance_to(second_mob.global_position)
 	assert_true(
 		new_distance < initial_distance,
-		"Mobs did not get closer to each other. Initial distance: %s, New distance: %s" % [initial_distance, new_distance]
+		(
+			"Mobs did not get closer to each other. Initial distance: %s, New distance: %s"
+			% [initial_distance, new_distance]
+		)
 	)
-	
+
 	# Test that the mob transitions into the mob ranged attack state
 	await wait_frames(30)
 	var first_state: State = first_mob.get_current_state()
 	assert_not_null(first_state, "Mob has no state")
-	assert_is(first_state,MobRangedAttack,"A different state then expected")
-	
+	assert_is(first_state, MobRangedAttack, "A different state then expected")
+
 	# Test that the second mob transitions into the MobFollow state
 	var second_state: State = second_mob.get_current_state()
 	assert_not_null(second_state, "Second mob has no state")
-	var mob_has_transitioned = func():
-		return second_state is MobFollow
-	assert_true(await wait_until(mob_has_transitioned, 10, 1),"Mob should have transitioned")
-	
+	var mob_has_transitioned = func(): return second_state is MobFollow
+	assert_true(await wait_until(mob_has_transitioned, 10, 1), "Mob should have transitioned")
+
 	var furniture_at_y_level: Array[FurnitureStaticSrv] = test_chunk.get_furniture_at_y_level(1)
 	# Need to set the level_generator to some random node because when the furniture
 	# takes damage, it needs to get the tree node from the level_generator
 	Helper.map_manager.level_generator = entity_node
-	
+
 	# Ensure at least one furniture piece has taken damage
 	var furniture_damaged = func():
 		for furniture in furniture_at_y_level:
@@ -357,15 +409,28 @@ func test_mob_ranged_vs_furniture():
 				return true
 		return false
 
-	assert_true(await wait_until(furniture_damaged, 10, 1), "At least one furniture piece should have taken damage.")
-	
-	Helper.map_manager.level_generator = null # Reset the level_generator
+	assert_true(
+		await wait_until(furniture_damaged, 10, 1),
+		"At least one furniture piece should have taken damage."
+	)
 
-	# Kill second_mob. 
+	Helper.map_manager.level_generator = null  # Reset the level_generator
+
+	# Kill second_mob.
 	second_mob.terminate()
-	second_mob.get_hit({"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},"hit_chance":100})
-	# Kill first. 
+	second_mob.get_hit(
+		{
+			"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},
+			"hit_chance": 100
+		}
+	)
+	# Kill first.
 	first_mob.terminate()
-	first_mob.get_hit({"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},"hit_chance":100})
+	first_mob.get_hit(
+		{
+			"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},
+			"hit_chance": 100
+		}
+	)
 	projectiles_container.free()
 	entity_node.free()

--- a/Tests/Unit/test_player.gd
+++ b/Tests/Unit/test_player.gd
@@ -2,8 +2,8 @@ extends GutTest
 
 # This script is used to test the player
 
-var scene_selector 
-var players: Array # Variable for all existing players, just one for now
+var scene_selector
+var players: Array  # Variable for all existing players, just one for now
 var player: Player
 var test_chunk: Chunk
 var mock_level_manager: Node3D
@@ -34,7 +34,7 @@ func before_each():
 	# We expect the player to start here, just like in level_generation.tscn
 	player.global_position = Vector3(0, 1.5, 15)
 
-	test_chunk.mypos = Vector3(0, 0, 0) # Example position (chunk (1, 2) with 32x32 blocks)
+	test_chunk.mypos = Vector3(0, 0, 0)  # Example position (chunk (1, 2) with 32x32 blocks)
 
 
 # Runs after each test.
@@ -43,15 +43,18 @@ func after_each():
 	# Awaiting the `chunk_unloaded` signal will produce an error in GUT somehow, so don't do that
 	test_chunk.unload_chunk()
 	# Verify that the load state is `UNLOADING`)
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.UNLOADING, "Chunk load_state should be UNLOADING.")
-	var chunk_is_unloaded = func():
-		return test_chunk == null
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.UNLOADING, "Chunk load_state should be UNLOADING."
+	)
+	var chunk_is_unloaded = func(): return test_chunk == null
 	# Calls chunk_is_unloaded every second until it returns true and asserts on the returned value
-	assert_true(await wait_until(chunk_is_unloaded, 10, 1),"Chunk should be unloaded in 10 seconds")
+	assert_true(
+		await wait_until(chunk_is_unloaded, 10, 1), "Chunk should be unloaded in 10 seconds"
+	)
 
-	var mobs: Array = get_tree().get_nodes_in_group("mobs") 
-	assert_eq(mobs.size(),0,"too many mobs")
-	
+	var mobs: Array = get_tree().get_nodes_in_group("mobs")
+	assert_eq(mobs.size(), 0, "too many mobs")
+
 	if test_chunk and is_instance_valid(test_chunk):
 		test_chunk.queue_free()
 	if mock_level_manager:
@@ -64,94 +67,127 @@ func after_each():
 
 
 #Function tests for the presence of a player
-func test_player_basics()->void:
-	test_chunk.chunk_data = {"id": "basic_test_map","rotation": 0}
+func test_player_basics() -> void:
+	test_chunk.chunk_data = {"id": "basic_test_map", "rotation": 0}
 	add_child(test_chunk)
 	await get_tree().process_frame
 	# Test if chunk state is set correctly
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state.")
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state."
+	)
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
 	# Start testing the player basics
-	players = get_tree().get_nodes_in_group("Players") 
-	assert_eq(players.size(),1,"too many or not enough players")
-	
-	assert_true(player.is_alive,"Oops player spawned dead")
+	players = get_tree().get_nodes_in_group("Players")
+	assert_eq(players.size(), 1, "too many or not enough players")
+
+	assert_true(player.is_alive, "Oops player spawned dead")
 	assert_eq(player.current_stamina, player.max_stamina, "Stamina is loading incorrectly!")
 	assert_eq(player.global_position, Vector3(0, 1.5, 15), "Player spawned in the wrong location!")
-	assert_false(player.knockback_active,"Player spawned with knockback error")
+	assert_false(player.knockback_active, "Player spawned with knockback error")
 
 
 # Test knockback mechanics
 func test_knockback():
-	test_chunk.chunk_data = {"id": "basic_test_map","rotation": 0}
+	test_chunk.chunk_data = {"id": "basic_test_map", "rotation": 0}
 	add_child(test_chunk)
 	await get_tree().process_frame
 	# Test if chunk state is set correctly
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state.")
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state."
+	)
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
-	var player_can_move = func():
-		return player.time_since_ready > player.delay_before_movement
-	assert_true(await wait_until(player_can_move, 3, 1),"Player should be able to move in 3 seconds")
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
+	var player_can_move = func(): return player.time_since_ready > player.delay_before_movement
+	assert_true(
+		await wait_until(player_can_move, 3, 1), "Player should be able to move in 3 seconds"
+	)
 
 	var initial_position = player.global_position
 	player._perform_knockback(5.0, initial_position + Vector3(-1, 0, 0))
-	assert_true(player.knockback_active, "Knockback should be active after calling _perform_knockback.")
+	assert_true(
+		player.knockback_active, "Knockback should be active after calling _perform_knockback."
+	)
 	await wait_frames(10)
-	assert_true(player.global_position != initial_position, "Player should have moved due to knockback.")
+	assert_true(
+		player.global_position != initial_position, "Player should have moved due to knockback."
+	)
 
 
 # Test stun effect
 func test_stun_effect():
-	test_chunk.chunk_data = {"id": "basic_test_map","rotation": 0}
+	test_chunk.chunk_data = {"id": "basic_test_map", "rotation": 0}
 	add_child(test_chunk)
 	await get_tree().process_frame
 	# Test if chunk state is set correctly
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state.")
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state."
+	)
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
-	player.delay_before_movement = 0 # Make sure the player is processing in time
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
+	player.delay_before_movement = 0  # Make sure the player is processing in time
 	player.add_stun(5.0)
 	assert_true(player.is_stunned(), "Player should be stunned after receiving stun.")
-	
+
 	await wait_frames(60)  # Allow stun to wear off
 	assert_false(player.is_stunned(), "Player should recover from stun over time.")
 
 
 # Test skill progression
 func test_skill_progression():
-	test_chunk.chunk_data = {"id": "basic_test_map","rotation": 0}
+	test_chunk.chunk_data = {"id": "basic_test_map", "rotation": 0}
 	add_child(test_chunk)
 	await get_tree().process_frame
 	# Test if chunk state is set correctly
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state.")
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state."
+	)
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
 	var initial_level = player.get_skill_level("athletics")
 	player.add_skill_xp("athletics", 200)  # Should level up twice
-	
-	assert_true(player.get_skill_level("athletics") > initial_level, "Skill level should increase after gaining XP.")
+
+	assert_true(
+		player.get_skill_level("athletics") > initial_level,
+		"Skill level should increase after gaining XP."
+	)
 
 
 # Test player state saving and loading
 func test_player_state_save_load():
-	test_chunk.chunk_data = {"id": "basic_test_map","rotation": 0}
+	test_chunk.chunk_data = {"id": "basic_test_map", "rotation": 0}
 	add_child(test_chunk)
 	await get_tree().process_frame
 	# Test if chunk state is set correctly
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state.")
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state."
+	)
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
 	player.current_stamina = 50
 	player.current_nutrition = 70
 	var saved_state = player.get_state()
-	
+
 	# Reset and reload state
 	player.set_state({"stamina": 100, "nutrition": 30})
 	assert_eq(player.current_stamina, 100, "Stamina should be set to 100.")
@@ -170,53 +206,66 @@ func test_player_vs_melee_mob():
 	var mock_target_manager = TargetManager.new()
 	mock_target_manager.name = "TargetManager"
 	add_child(mock_target_manager)
-	
-	test_chunk.chunk_data = {"id": "basic_mob_test_map","rotation": 0}
+
+	test_chunk.chunk_data = {"id": "basic_mob_test_map", "rotation": 0}
 	add_child(test_chunk)
 	await get_tree().process_frame
 	# Test if chunk state is set correctly
-	assert_eq(test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state.")
+	assert_eq(
+		test_chunk.load_state, Chunk.LoadStates.LOADING, "Chunk did not start in LOADING state."
+	)
 	# Wait for `chunk_generated` signal before verifying post-generation state
-	assert_true(await wait_for_signal(test_chunk.chunk_generated, 5), "Chunk should have emitted chunk_generated signal.")
-	
+	assert_true(
+		await wait_for_signal(test_chunk.chunk_generated, 5),
+		"Chunk should have emitted chunk_generated signal."
+	)
+
 	# Start testing the player basics
-	players = get_tree().get_nodes_in_group("Players") 
-	assert_eq(players.size(),1,"too many or not enough players")
-	player.global_position = Vector3(13,1.5,15)
-	
-	var mobs: Array = get_tree().get_nodes_in_group("mobs") 
-	assert_eq(mobs.size(),1,"too many or not enough mobs")
+	players = get_tree().get_nodes_in_group("Players")
+	assert_eq(players.size(), 1, "too many or not enough players")
+	player.global_position = Vector3(13, 1.5, 15)
+
+	var mobs: Array = get_tree().get_nodes_in_group("mobs")
+	assert_eq(mobs.size(), 1, "too many or not enough mobs")
 	var first_mob: Mob = mobs[0]
-	assert_eq(first_mob.rmob.id,"generic_test_mob","A different mob spawned then expected")
-	assert_eq(first_mob.mob_position,Vector3(15.5,1.5,15.5),"Mob spawned somewhere else")
-	
+	assert_eq(first_mob.rmob.id, "generic_test_mob", "A different mob spawned then expected")
+	assert_eq(first_mob.mob_position, Vector3(15.5, 1.5, 15.5), "Mob spawned somewhere else")
+
 	# Test that the mob transitions into the mob attack state
 	var first_state: State = first_mob.get_current_state()
 	assert_not_null(first_state, "Mob has no state")
-	assert_is(first_state,MobFollow,"Mob should have MobFollow state")
+	assert_is(first_state, MobFollow, "Mob should have MobFollow state")
 
 	# Check that the mob has the required attack and that the player has the relevant attribute
 	var mobattack: Dictionary = first_mob.get_attack_of_type("melee")
-	assert_eq(mobattack.id,"generic_melee_attack","Mob doesn't have the required attack")
+	assert_eq(mobattack.id, "generic_melee_attack", "Mob doesn't have the required attack")
 	var playerattribute: PlayerAttribute = player.attributes.get("generic_test_attribute", null)
 	assert_not_null(playerattribute, "Player lacks the required attribute")
 	assert_true(playerattribute.default_mode.is_at_max(), "Player should have max of attribute")
-	
+
 	# Wait for the mob to change to MobAttack
-	assert_true(await wait_for_signal(first_state.Transistioned, 5), "Mob doesn't transition")
+	assert_true(await wait_for_signal(first_state.Transitioned, 5), "Mob doesn't transition")
 	first_state = first_mob.get_current_state()
-	var mob_has_transitioned = func():
-		return first_mob.get_current_state() is MobAttack
+	var mob_has_transitioned = func(): return first_mob.get_current_state() is MobAttack
 	# Replace the existing assert_true line with this one:
-	assert_true(await wait_until(mob_has_transitioned, 10, 1), 
-		"Mob should have transitioned, but current state is: %s" % [first_mob.get_current_state().get_class()])
-	
-	var player_has_taken_damage = func():
-		return not playerattribute.default_mode.is_at_max()
-	assert_true(await wait_until(player_has_taken_damage, 10, 1),"Player should have taken damage")
-	
+	assert_true(
+		await wait_until(mob_has_transitioned, 10, 1),
+		(
+			"Mob should have transitioned, but current state is: %s"
+			% [first_mob.get_current_state().get_class()]
+		)
+	)
+
+	var player_has_taken_damage = func(): return not playerattribute.default_mode.is_at_max()
+	assert_true(await wait_until(player_has_taken_damage, 10, 1), "Player should have taken damage")
+
 	# Kill first_mob. Alternatively, wait for one to kill the other but that will take time
-	first_mob.get_hit({"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},"hit_chance":100})
-	
+	first_mob.get_hit(
+		{
+			"attack": {"id": "generic_melee_attack", "damage_multiplier": 100, "type": "melee"},
+			"hit_chance": 100
+		}
+	)
+
 	await get_tree().process_frame
 	Helper.player = null

--- a/Tests/Unit/test_state_transitions.gd
+++ b/Tests/Unit/test_state_transitions.gd
@@ -1,0 +1,15 @@
+extends GutTest
+
+
+class TestState:
+	extends State
+
+	func enter():
+		Transitioned.emit(self, "next")
+
+
+func test_transitioned_signal_fires():
+	var state = TestState.new()
+	add_child(state)
+	state.call_deferred("enter")
+	assert_true(await wait_for_signal(state.Transitioned, 1), "Transitioned signal did not fire")

--- a/Tests/Unit/test_state_transitions.gd.uid
+++ b/Tests/Unit/test_state_transitions.gd.uid
@@ -1,0 +1,1 @@
+uid://wigfyvuwurq0


### PR DESCRIPTION
## Summary
- rename misnamed mob state transition signal to `Transitioned`
- update mob state scripts and tests to use the renamed signal
- add unit test for state transition signal emission

## Testing
- `godot --headless --import`
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68949b65ac7083258ed35f021b627a5b