### PR TITLE
docs: add PRD for unique itemgroup entries

### DIFF
--- a/.project-management/current-prd/prd-itemgroup-unique.md
+++ b/.project-management/current-prd/prd-itemgroup-unique.md
@@ -7,7 +7,6 @@
 
 ## 3. User Stories
 - **As a modder**, I want the editor to ignore duplicate item drops so that itemgroups remain consistent.
-- **As a modder**, I want confidence that saving and loading itemgroups works reliably without duplicate IDs.
 
 ## 4. Functional Requirements
 1. When a modder drops an item onto an itemgroup editor, the system must check if the item ID already exists in the group.
@@ -27,7 +26,6 @@
 
 ## 8. Success Metrics
 - Modders can drop items into the itemgroup editor without creating duplicates.
-- Itemgroup files save and load without issues related to duplicate IDs.
 
 ## 9. Open Questions
 - None.

--- a/.project-management/current-prd/prd-itemgroup-unique.md
+++ b/.project-management/current-prd/prd-itemgroup-unique.md
@@ -1,0 +1,36 @@
+## 1. Introduction/Overview
+- The itemgroup editor currently allows the same item to be added multiple times, which leads to uncertain spawn counts and potential save/load issues. This PRD defines a fix to ensure each item appears only once per itemgroup for modders.
+
+## 2. Goals
+- Ensure itemgroup entries remain unique within the editor.
+- Prevent accidental duplication without disrupting existing data.
+
+## 3. User Stories
+- **As a modder**, I want the editor to ignore duplicate item drops so that itemgroups remain consistent.
+- **As a modder**, I want confidence that saving and loading itemgroups works reliably without duplicate IDs.
+
+## 4. Functional Requirements
+1. When a modder drops an item onto an itemgroup editor, the system must check if the item ID already exists in the group.
+2. If the item ID is already present, the drop must be ignored and the itemgroup must remain unchanged.
+3. Existing itemgroups should be treated as duplicate-free; the system must not attempt automatic cleanup.
+4. Any new duplicates must be prevented without notifying the user with an error.
+
+## 5. Non-Goals
+- Cleaning up pre-existing duplicates in itemgroups.
+- Supporting nested itemgroups or case-insensitive matching.
+
+## 6. Design Considerations (Optional)
+- None.
+
+## 7. Technical Considerations (Optional)
+- The fix will involve updating `_handle_item_drop` in `itemgroupeditor.gd` to skip additions when the item ID is already in the list.
+
+## 8. Success Metrics
+- Modders can drop items into the itemgroup editor without creating duplicates.
+- Itemgroup files save and load without issues related to duplicate IDs.
+
+## 9. Open Questions
+- None.
+
+## 10. Referenced PRD-background files
+- None.


### PR DESCRIPTION
## Summary
- add PRD outlining unique item enforcement for itemgroup editor

## Testing
- `godot --headless --import` *(fails: Unrecognized UID)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(fails: missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_6896308968748325836b950f0459ba4e