### PR TITLE
Refactor LevelManager to use player spawn signal

### DIFF
--- a/.project-management/current-prd/tasks-prd-decouple-tightly-coupled-scripts-scenes.md
+++ b/.project-management/current-prd/tasks-prd-decouple-tightly-coupled-scripts-scenes.md
@@ -66,12 +66,12 @@
 - Unit tests should typically be placed in `/Tests/Unit/`.
 
 ## Tasks
-- [ ] 4.0 Update `LevelManager` to receive player references via signal
-  - [ ] 4.1 Define a `player_spawned` signal in the relevant player or spawner script.
-  - [ ] 4.2 Modify `LevelManager.gd` to connect to `player_spawned` instead of polling groups.
-  - [ ] 4.3 Store the player reference provided via signal and update internal logic accordingly.
-  - [ ] 4.4 Clean up any residual group-check logic or unused variables.
-- [ ] 5.0 test
-  - [ ] 5.4 Ensure tests run and pass after refactoring.
+- [x] 4.0 Update `LevelManager` to receive player references via signal
+  - [x] 4.1 Define a `player_spawned` signal in the relevant player or spawner script.
+  - [x] 4.2 Modify `LevelManager.gd` to connect to `player_spawned` instead of polling groups.
+  - [x] 4.3 Store the player reference provided via signal and update internal logic accordingly.
+  - [x] 4.4 Clean up any residual group-check logic or unused variables.
+- [c] 5.0 test
+  - [c] 5.4 Ensure tests run and pass after refactoring.
 
 *End of document*

--- a/LevelManager.gd
+++ b/LevelManager.gd
@@ -1,14 +1,17 @@
 extends Node3D
 
-  # Initialize with a value that's unlikely to be a valid starting Y-level
+# Initialize with a value that's unlikely to be a valid starting Y-level
 var last_player_y_level: float = -1
+var player: Player = null
+
 
 func _ready():
 	Helper.signal_broker.initial_chunks_generated.connect(_on_initial_chunks_generated)
+	Helper.signal_broker.player_spawned.connect(_on_player_spawned)
+
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
-	var player = get_tree().get_first_node_in_group("Players")
 	if player:
 		var current_player_y = player.global_position.y
 
@@ -17,16 +20,22 @@ func _process(_delta):
 			update_visibility(current_player_y)
 			last_player_y_level = current_player_y
 
+
 func update_visibility(player_y: float):
 	# Update level visibility
 	for level in get_tree().get_nodes_in_group("maplevels"):
-		var is_above_player = level.y-0.38 > player_y
+		var is_above_player = level.y - 0.38 > player_y
 		level.visible = not is_above_player
 
 
 # When the initial chunks around the player are generated,
 # we update the visibility even before the player moves.
 func _on_initial_chunks_generated():
-	var player = get_tree().get_first_node_in_group("Players")
 	if player:
 		update_visibility(player.global_position.y)
+
+
+func _on_player_spawned(playernode: Player):
+	player = playernode
+	last_player_y_level = player.global_position.y
+	update_visibility(last_player_y_level)


### PR DESCRIPTION
## Summary
- Use `player_spawned` signal to obtain player reference in `LevelManager`
- Remove group polling and store player reference
- Update project task list

## Testing
- `godot --headless --import` *(failed: Unrecognized UID)*
- `godot --headless -s --path "$PWD" addons/gut/gut_cmdln.gd -gexit -gdir=res://Tests/Unit` *(failed: GutUtils not declared; missing resources)*


------
https://chatgpt.com/codex/tasks/task_e_6896f6bdf1e88325b2e6f8eb2781ddbe