### PR TITLE
Add tile palette references to map recipes

### DIFF
--- a/Documentation/Game_design/Map_generation_plan.md
+++ b/Documentation/Game_design/Map_generation_plan.md
@@ -126,6 +126,7 @@ The generator currently supports:
 * ordered `set`, `rectangle`, `rectangle_outline`, `line`, and `scatter` operations;
 * inclusive Bresenham line rasterization;
 * deterministic scatter by count or density;
+* root-level weighted tile palettes referenced by base tiles and placement operations;
 * fixed tile rotations;
 * deterministic random rotations;
 * `null` region tiles that produce `{}`;
@@ -149,7 +150,7 @@ unused levels: []
 
 ## 5. Generator and validator tests: complete for version 1
 
-The current Python test suite contains 34 tests and passes.
+The current Python test suite contains 38 tests and passes.
 
 Coverage includes:
 
@@ -167,6 +168,7 @@ Coverage includes:
 * unknown fields;
 * invalid IDs;
 * unknown tile IDs;
+* palette references, weighted deterministic selection, and malformed palette rejection;
 * invalid metadata;
 * malformed tile databases;
 * out-of-bounds placement;
@@ -221,8 +223,8 @@ The current recipe language is intentionally minimal. It cannot yet express most
 
 It does not currently support:
 
+* reusable pattern definitions beyond tile palettes;
 * circles or irregular regions;
-* weighted tile variation;
 * terrain blending;
 * multiple populated vertical levels;
 * features or furniture;
@@ -346,7 +348,7 @@ A developer can run one documented command, launch Godot, and inspect at least t
 
 ## Phase 4B — Tile palettes and reusable patterns
 
-**Status: next**
+**Status: in progress**
 
 Raw tile IDs are cumbersome and encourage agents to invent invalid identifiers. Introduce semantic recipe-level palettes.
 
@@ -357,21 +359,21 @@ Example:
   "palette": {
     "ground": [
       {
-        "tile": "grass",
+        "id": "grass_plain_01",
         "weight": 8
       },
       {
-        "tile": "grass_variant",
+        "id": "grass_flowers_00",
         "weight": 2
       }
     ],
     "path": [
       {
-        "tile": "dirt-light",
+        "id": "dirt_light_00",
         "weight": 3
       },
       {
-        "tile": "dirt-dark",
+        "id": "grass_dirt_00",
         "weight": 1
       }
     ]
@@ -379,14 +381,19 @@ Example:
 }
 ```
 
-Goals:
+Delivered:
 
+* root-level semantic tile palettes;
 * weighted deterministic selection;
-* named tile sets;
-* automatic rotation rules;
-* reusable pattern definitions;
-* fewer raw IDs throughout recipes;
-* centralized checking of allowed tiles.
+* palette references from `base_tile`, legacy `regions`, and every placement operation;
+* strict palette validation and known tile-ID checking;
+* updated example recipe using palettes for ground, clearing, paths, and flowers.
+
+Remaining goals:
+
+* reusable pattern definitions beyond weighted tile sets;
+* richer automatic rotation rules;
+* additional examples that reduce raw IDs throughout recipes.
 
 ### Success criterion
 

--- a/Documentation/Modding/map_recipe_generator.md
+++ b/Documentation/Modding/map_recipe_generator.md
@@ -28,12 +28,36 @@ The root must be a JSON object with these fields:
 | `description` | non-empty string | Map description. |
 | `seed` | integer | Fixed seed used by random rotations and scatter. Recipe input only; the map format does not store it. |
 | `base_tile` | tile object | Tile initially placed in every cell. |
+| `palette` | object | Named weighted tile sets that tile objects can reference. Optional; defaults to `{}`. |
 | `regions` | array | Legacy filled rectangles. Optional; defaults to `[]`. |
 | `operations` | array | Ordered placement operations. Optional; defaults to `[]`. |
 
 A recipe does not define map dimensions: all generated maps are 32 x 32. Coordinates start at the top-left. Every shape must fit entirely within the map; operations are never silently clipped.
 
-A tile object has a required `id` from the selected `Tiles.json` and an optional `rotation`. Rotation is `0`, `90`, `180`, `270`, or `"random"`. Operation tiles may be `null`, which writes the project's empty-tile representation, `{}`.
+A tile object has exactly one of:
+
+- `id`: a raw tile ID from the selected `Tiles.json`; or
+- `palette`: the name of a root-level palette.
+
+It may also include an optional `rotation` when using `id`. Rotation is `0`, `90`, `180`, `270`, or `"random"`. Operation tiles may be `null`, which writes the project's empty-tile representation, `{}`.
+
+Palette entries are objects with `id`, optional positive integer `weight` (default `1`), and optional `rotation`. Palette names may contain only letters, numbers, underscores, and hyphens. Palette selection uses the same seeded random-number generator as scatter and random rotation, so the same complete recipe and seed produce identical output. Changing a recipe from a raw tile to a palette reference may change later random choices because palette selection consumes random numbers.
+
+```json
+{
+  "palette": {
+    "ground": [
+      {"id": "grass_plain_01", "weight": 8, "rotation": "random"},
+      {"id": "grass_flowers_00", "weight": 2, "rotation": "random"}
+    ],
+    "path": [
+      {"id": "dirt_light_00", "weight": 3},
+      {"id": "grass_dirt_00", "weight": 1, "rotation": "random"}
+    ]
+  },
+  "base_tile": {"palette": "ground"}
+}
+```
 
 Legacy `regions` are applied first in array order, followed by `operations` in array order. Later placements overwrite earlier cells. `regions` remain supported for version-one recipes and use the same filled-rectangle placement implementation as `rectangle` operations.
 
@@ -97,4 +121,4 @@ The generator rejects unknown fields at every recipe level, root-level dimension
 
 The output uses 21 levels, with the generated row-major grid at index 10. It sets `categories` to `[]`, `weight` to `1000`, and all four connections to `"ground"`. It omits `areas`, matching `DMap.get_data()` when the area list is empty.
 
-The generator does not yet create palettes, features, furniture, areas, roads as semantic objects, buildings, towns, additional levels, or complex templates. Structural validity also does not yet guarantee walkability or gameplay quality.
+The generator does not yet create features, furniture, areas, roads as semantic objects, buildings, towns, additional levels, or complex templates. Structural validity also does not yet guarantee walkability or gameplay quality.

--- a/Tools/examples/map_recipe.json
+++ b/Tools/examples/map_recipe.json
@@ -4,8 +4,7 @@
 	"description": "A deterministic meadow with a clearing, path, and scattered flowers.",
 	"seed": 20260715,
 	"base_tile": {
-		"id": "grass_plain_01",
-		"rotation": "random"
+		"palette": "ground"
 	},
 	"operations": [
 		{
@@ -18,8 +17,7 @@
 			},
 			"count": 90,
 			"tile": {
-				"id": "grass_flowers_00",
-				"rotation": "random"
+				"palette": "flowers"
 			}
 		},
 		{
@@ -29,8 +27,7 @@
 			"width": 12,
 			"height": 14,
 			"tile": {
-				"id": "grass_plain_01",
-				"rotation": "random"
+				"palette": "clearing"
 			}
 		},
 		{
@@ -40,8 +37,7 @@
 			"width": 12,
 			"height": 14,
 			"tile": {
-				"id": "grass_dirt_00",
-				"rotation": "random"
+				"palette": "path"
 			}
 		},
 		{
@@ -55,7 +51,7 @@
 				16
 			],
 			"tile": {
-				"id": "dirt_light_00"
+				"palette": "path"
 			}
 		},
 		{
@@ -66,5 +62,54 @@
 				"id": "grass_flowers_01"
 			}
 		}
-	]
+	],
+	"palette": {
+		"ground": [
+			{
+				"id": "grass_plain_01",
+				"weight": 8,
+				"rotation": "random"
+			},
+			{
+				"id": "grass_flowers_00",
+				"weight": 2,
+				"rotation": "random"
+			}
+		],
+		"clearing": [
+			{
+				"id": "grass_plain_01",
+				"weight": 4,
+				"rotation": "random"
+			},
+			{
+				"id": "grass_dirt_00",
+				"weight": 1,
+				"rotation": "random"
+			}
+		],
+		"path": [
+			{
+				"id": "dirt_light_00",
+				"weight": 3
+			},
+			{
+				"id": "grass_dirt_00",
+				"weight": 1,
+				"rotation": "random"
+			}
+		],
+		"flowers": [
+			{
+				"id": "grass_flowers_00",
+				"weight": 1,
+				"rotation": "random"
+			},
+			{
+				"id": "grass_flowers_01",
+				"weight": 1,
+				"rotation": "random"
+			}
+		]
+	}
 }

--- a/Tools/map_generator.py
+++ b/Tools/map_generator.py
@@ -30,7 +30,9 @@ DEFAULT_CONNECTIONS = {
     "west": "ground",
 }
 VALID_ROTATIONS = (0, 90, 180, 270)
-TILE_FIELDS = {"id", "rotation"}
+TILE_FIELDS = {"id", "palette", "rotation"}
+PALETTE_FIELDS = {"id", "weight", "rotation"}
+PALETTE_NAME_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
 REGION_FIELDS = {"x", "y", "width", "height", "tile"}
 SET_FIELDS = {"type", "x", "y", "tile"}
 RECTANGLE_FIELDS = {"type", "x", "y", "width", "height", "tile"}
@@ -44,6 +46,7 @@ RECIPE_FIELDS = {
     "description",
     "seed",
     "base_tile",
+    "palette",
     "regions",
     "operations",
 }
@@ -135,12 +138,55 @@ def _tile_ids(tiles_path: Path) -> set[str]:
     }
 
 
+def _validate_palette_entry(
+    entry: Any,
+    known_tiles: set[str],
+    context: str,
+) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise RecipeError(f"{context} must be an object")
+    unknown_fields = sorted(set(entry) - PALETTE_FIELDS)
+    if unknown_fields:
+        raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    tile_spec = {field: entry[field] for field in ("id", "rotation") if field in entry}
+    tile_id, rotation = _validate_tile_spec(tile_spec, known_tiles, context)
+    weight = entry.get("weight", 1)
+    if type(weight) is not int or weight <= 0:
+        raise RecipeError(f"{context}.weight must be a positive integer")
+    return {"id": tile_id, "rotation": rotation, "weight": weight}
+
+
+def _validate_palette(
+    palette: Any,
+    known_tiles: set[str],
+) -> dict[str, list[dict[str, Any]]]:
+    if not isinstance(palette, dict):
+        raise RecipeError("palette must be an object")
+    validated: dict[str, list[dict[str, Any]]] = {}
+    for name, entries in palette.items():
+        if not isinstance(name, str) or not name.strip():
+            raise RecipeError("palette names must be non-empty strings")
+        _validate_unicode(name, f"palette.{name}")
+        if PALETTE_NAME_PATTERN.fullmatch(name) is None:
+            raise RecipeError(
+                f"palette name '{name}' may contain only letters, numbers, underscores, and hyphens"
+            )
+        if not isinstance(entries, list) or not entries:
+            raise RecipeError(f"palette.{name} must be a non-empty array")
+        validated[name] = [
+            _validate_palette_entry(entry, known_tiles, f"palette.{name}[{index}]")
+            for index, entry in enumerate(entries)
+        ]
+    return validated
+
+
 def _validate_tile_spec(
     spec: Any,
     known_tiles: set[str],
     context: str,
     *,
     allow_empty: bool = False,
+    palette: dict[str, list[dict[str, Any]]] | None = None,
 ) -> tuple[str | None, int | str]:
     if spec is None and allow_empty:
         return None, 0
@@ -150,6 +196,22 @@ def _validate_tile_spec(
     unknown_fields = sorted(set(spec) - TILE_FIELDS)
     if unknown_fields:
         raise RecipeError(f"unknown {context} field '{unknown_fields[0]}'")
+    has_id = "id" in spec
+    has_palette = "palette" in spec
+    if has_id == has_palette:
+        raise RecipeError(f"{context} must define exactly one of id or palette")
+    if has_palette:
+        if "rotation" in spec:
+            raise RecipeError(f"{context}.rotation cannot be used with palette")
+        palette_name = spec.get("palette")
+        if not isinstance(palette_name, str) or not palette_name.strip():
+            raise RecipeError(f"{context}.palette must be a non-empty string")
+        _validate_unicode(palette_name, f"{context}.palette")
+        if palette is None or palette_name not in palette:
+            raise RecipeError(
+                f"{context}.palette references unknown palette '{palette_name}'"
+            )
+        return None, 0
     tile_id = spec.get("id")
     if not isinstance(tile_id, str) or not tile_id.strip():
         raise RecipeError(f"{context}.id must be a non-empty string")
@@ -164,6 +226,19 @@ def _validate_tile_spec(
     return tile_id, rotation
 
 
+def _select_weighted_palette_entry(
+    entries: list[dict[str, Any]], rng: random.Random
+) -> dict[str, Any]:
+    total_weight = sum(entry["weight"] for entry in entries)
+    selection = rng.randrange(total_weight)
+    cumulative = 0
+    for entry in entries:
+        cumulative += entry["weight"]
+        if selection < cumulative:
+            return entry
+    return entries[-1]
+
+
 def _make_tile(
     spec: Any,
     rng: random.Random,
@@ -171,10 +246,19 @@ def _make_tile(
     context: str,
     *,
     allow_empty: bool = False,
+    palette: dict[str, list[dict[str, Any]]] | None = None,
 ) -> dict[str, Any]:
     tile_id, rotation = _validate_tile_spec(
-        spec, known_tiles, context, allow_empty=allow_empty
+        spec, known_tiles, context, allow_empty=allow_empty, palette=palette
     )
+    if isinstance(spec, dict) and "palette" in spec:
+        if palette is None:
+            raise RecipeError(
+                f"{context}.palette references unknown palette '{spec['palette']}'"
+            )
+        entry = _select_weighted_palette_entry(palette[spec["palette"]], rng)
+        tile_id = entry["id"]
+        rotation = entry["rotation"]
     if tile_id is None:
         return {}
     if rotation == "random":
@@ -187,9 +271,7 @@ def _make_tile(
 
 def _coordinate(value: Any, context: str, maximum: int) -> int:
     if type(value) is not int or not 0 <= value < maximum:
-        raise RecipeError(
-            f"{context} must be an integer between 0 and {maximum - 1}"
-        )
+        raise RecipeError(f"{context} must be an integer between 0 and {maximum - 1}")
     return value
 
 
@@ -198,6 +280,7 @@ def _apply_set(
     operation: dict[str, Any],
     rng: random.Random,
     known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
     context: str,
 ) -> None:
     unknown_fields = sorted(set(operation) - SET_FIELDS)
@@ -206,7 +289,12 @@ def _apply_set(
     x = _coordinate(operation.get("x"), f"{context}.x", MAP_WIDTH)
     y = _coordinate(operation.get("y"), f"{context}.y", MAP_HEIGHT)
     level[y * MAP_WIDTH + x] = _make_tile(
-        operation.get("tile"), rng, known_tiles, f"{context}.tile", allow_empty=True
+        operation.get("tile"),
+        rng,
+        known_tiles,
+        f"{context}.tile",
+        allow_empty=True,
+        palette=palette,
     )
 
 
@@ -232,6 +320,7 @@ def _apply_rectangle(
     spec: dict[str, Any],
     rng: random.Random,
     known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
     context: str,
     fields: set[str],
 ) -> None:
@@ -247,6 +336,7 @@ def _apply_rectangle(
                 known_tiles,
                 f"{context}.tile",
                 allow_empty=True,
+                palette=palette,
             )
 
 
@@ -255,6 +345,7 @@ def _apply_rectangle_outline(
     operation: dict[str, Any],
     rng: random.Random,
     known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
     context: str,
 ) -> None:
     unknown_fields = sorted(set(operation) - RECTANGLE_FIELDS)
@@ -274,6 +365,7 @@ def _apply_rectangle_outline(
                     known_tiles,
                     f"{context}.tile",
                     allow_empty=True,
+                    palette=palette,
                 )
 
 
@@ -291,6 +383,7 @@ def _apply_line(
     operation: dict[str, Any],
     rng: random.Random,
     known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
     context: str,
 ) -> None:
     unknown_fields = sorted(set(operation) - LINE_FIELDS)
@@ -310,6 +403,7 @@ def _apply_line(
             known_tiles,
             f"{context}.tile",
             allow_empty=True,
+            palette=palette,
         )
         if x == target_x and y == target_y:
             break
@@ -327,6 +421,7 @@ def _apply_scatter(
     operation: dict[str, Any],
     rng: random.Random,
     known_tiles: set[str],
+    palette: dict[str, list[dict[str, Any]]],
     context: str,
 ) -> None:
     unknown_fields = sorted(set(operation) - SCATTER_FIELDS)
@@ -362,6 +457,7 @@ def _apply_scatter(
         known_tiles,
         f"{context}.tile",
         allow_empty=True,
+        palette=palette,
     )
     candidates = [
         y * MAP_WIDTH + x
@@ -375,6 +471,7 @@ def _apply_scatter(
             known_tiles,
             f"{context}.tile",
             allow_empty=True,
+            palette=palette,
         )
 
 
@@ -400,9 +497,12 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
     if type(seed) is not int:
         raise RecipeError("seed must be an integer")
     known_tiles = _tile_ids(Path(tiles_path))
+    palette = _validate_palette(recipe.get("palette", {}), known_tiles)
     rng = random.Random(seed)
     level = [
-        _make_tile(recipe.get("base_tile"), rng, known_tiles, "base_tile")
+        _make_tile(
+            recipe.get("base_tile"), rng, known_tiles, "base_tile", palette=palette
+        )
         for _ in range(MAP_WIDTH * MAP_HEIGHT)
     ]
 
@@ -413,7 +513,9 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
         context = f"regions[{index}]"
         if not isinstance(region, dict):
             raise RecipeError(f"{context} must be an object")
-        _apply_rectangle(level, region, rng, known_tiles, context, REGION_FIELDS)
+        _apply_rectangle(
+            level, region, rng, known_tiles, palette, context, REGION_FIELDS
+        )
 
     operations = recipe.get("operations", [])
     if not isinstance(operations, list):
@@ -426,17 +528,19 @@ def generate_map(recipe: dict[str, Any], tiles_path: Path) -> dict[str, Any]:
         if operation_type in OPERATION_TYPES and "tile" not in operation:
             raise RecipeError(f"{context}.tile is required")
         if operation_type == "set":
-            _apply_set(level, operation, rng, known_tiles, context)
+            _apply_set(level, operation, rng, known_tiles, palette, context)
         elif operation_type == "rectangle":
             _apply_rectangle(
-                level, operation, rng, known_tiles, context, RECTANGLE_FIELDS
+                level, operation, rng, known_tiles, palette, context, RECTANGLE_FIELDS
             )
         elif operation_type == "rectangle_outline":
-            _apply_rectangle_outline(level, operation, rng, known_tiles, context)
+            _apply_rectangle_outline(
+                level, operation, rng, known_tiles, palette, context
+            )
         elif operation_type == "line":
-            _apply_line(level, operation, rng, known_tiles, context)
+            _apply_line(level, operation, rng, known_tiles, palette, context)
         elif operation_type == "scatter":
-            _apply_scatter(level, operation, rng, known_tiles, context)
+            _apply_scatter(level, operation, rng, known_tiles, palette, context)
         else:
             raise RecipeError(
                 f"{context}.type has unknown operation '{operation_type}'"

--- a/Tools/tests/test_map_generator.py
+++ b/Tools/tests/test_map_generator.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from Tools.map_generator import RecipeError, generate_map, write_map
 from Tools.map_validator import MapValidator
 
-
 ROOT = Path(__file__).resolve().parents[2]
 TILES_PATH = ROOT / "Mods" / "Dimensionfall" / "Tiles" / "Tiles.json"
 
@@ -81,9 +80,7 @@ class MapGeneratorTests(unittest.TestCase):
 
     def test_null_region_tile_uses_the_existing_empty_dictionary_representation(self):
         recipe = valid_recipe()
-        recipe["regions"] = [
-            {"x": 0, "y": 0, "width": 1, "height": 1, "tile": None}
-        ]
+        recipe["regions"] = [{"x": 0, "y": 0, "width": 1, "height": 1, "tile": None}]
 
         generated = generate_map(recipe, TILES_PATH)
 
@@ -358,11 +355,7 @@ class MapGeneratorTests(unittest.TestCase):
             ),
             ({"base_tile": {"id": "missing_tile"}}, "unknown tile 'missing_tile'"),
             (
-                {
-                    "regions": [
-                        {"x": 0, "width": "two", "height": 1, "tile": None}
-                    ]
-                },
+                {"regions": [{"x": 0, "width": "two", "height": 1, "tile": None}]},
                 "regions\\[0\\].y must be a non-negative integer",
             ),
             (
@@ -407,6 +400,125 @@ class MapGeneratorTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, expected_message):
                     generate_map(recipe, TILES_PATH)
 
+    def test_palette_reference_works_for_base_tile(self):
+        recipe = valid_recipe()
+        recipe["palette"] = {
+            "ground": [
+                {"id": "grass_plain_01", "weight": 1},
+                {"id": "grass_flowers_00", "weight": 1},
+            ]
+        }
+        recipe["base_tile"] = {"palette": "ground"}
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        self.assertTrue(
+            all(tile["id"] in {"grass_plain_01", "grass_flowers_00"} for tile in level)
+        )
+        self.assertGreater(len({tile["id"] for tile in level}), 1)
+
+    def test_palette_reference_works_for_rectangle_and_scatter_operations(self):
+        recipe = valid_recipe()
+        recipe["base_tile"] = {"id": "grass_plain_01"}
+        recipe["palette"] = {
+            "path": [{"id": "dirt_light_00", "weight": 1}],
+            "flowers": [{"id": "grass_flowers_01", "weight": 1}],
+        }
+        recipe["operations"] = [
+            {
+                "type": "rectangle",
+                "x": 1,
+                "y": 1,
+                "width": 2,
+                "height": 2,
+                "tile": {"palette": "path"},
+            },
+            {
+                "type": "scatter",
+                "region": {"x": 10, "y": 10, "width": 3, "height": 3},
+                "count": 3,
+                "tile": {"palette": "flowers"},
+            },
+        ]
+
+        level = generate_map(recipe, TILES_PATH)["levels"][10]
+
+        for index in {33, 34, 65, 66}:
+            self.assertEqual(level[index], {"id": "dirt_light_00"})
+        self.assertEqual(level.count({"id": "grass_flowers_01"}), 3)
+
+    def test_weighted_palette_selection_is_deterministic_and_uses_weights(self):
+        recipe = valid_recipe()
+        recipe["seed"] = 7
+        recipe["palette"] = {
+            "ground": [
+                {"id": "grass_plain_01", "weight": 8},
+                {"id": "grass_flowers_00", "weight": 2},
+            ]
+        }
+        recipe["base_tile"] = {"palette": "ground"}
+
+        first = generate_map(recipe, TILES_PATH)["levels"][10]
+        second = generate_map(recipe, TILES_PATH)["levels"][10]
+        flower_count = first.count({"id": "grass_flowers_00"})
+        grass_count = first.count({"id": "grass_plain_01"})
+
+        self.assertEqual(first, second)
+        self.assertGreater(flower_count, 0)
+        self.assertGreater(grass_count, flower_count)
+
+    def test_palette_validation_rejects_malformed_entries_and_references(self):
+        cases = [
+            ({"base_tile": {"palette": "missing"}}, "unknown palette 'missing'"),
+            ({"palette": []}, "palette must be an object"),
+            (
+                {"palette": {"": [{"id": "grass_plain_01"}]}},
+                "palette names must be non-empty strings",
+            ),
+            (
+                {"palette": {"bad name": [{"id": "grass_plain_01"}]}},
+                "may contain only letters",
+            ),
+            ({"palette": {"ground": []}}, "palette.ground must be a non-empty array"),
+            (
+                {"palette": {"ground": ["grass_plain_01"]}},
+                r"palette.ground\[0\] must be an object",
+            ),
+            (
+                {"palette": {"ground": [{"weight": 1}]}},
+                "must define exactly one of id or palette",
+            ),
+            (
+                {"palette": {"ground": [{"id": "missing_tile"}]}},
+                "unknown tile 'missing_tile'",
+            ),
+            (
+                {"palette": {"ground": [{"id": "grass_plain_01", "weight": 0}]}},
+                "weight must be a positive integer",
+            ),
+            (
+                {"palette": {"ground": [{"id": "grass_plain_01", "rotation": 45}]}},
+                "rotation must be 0, 90, 180, 270, or 'random'",
+            ),
+            (
+                {"palette": {"ground": [{"id": "grass_plain_01", "extra": True}]}},
+                r"unknown palette.ground\[0\] field 'extra'",
+            ),
+            (
+                {
+                    "palette": {"ground": [{"id": "grass_plain_01"}]},
+                    "base_tile": {"id": "grass_plain_01", "palette": "ground"},
+                },
+                "base_tile must define exactly one of id or palette",
+            ),
+        ]
+        for changes, expected_message in cases:
+            with self.subTest(changes=changes):
+                recipe = valid_recipe()
+                recipe.update(changes)
+                with self.assertRaisesRegex(RecipeError, expected_message):
+                    generate_map(recipe, TILES_PATH)
+
     def test_recipe_dimensions_are_not_configurable(self):
         for field in ("width", "height"):
             with self.subTest(field=field):
@@ -447,7 +559,9 @@ class MapGeneratorTests(unittest.TestCase):
             tiles_path = Path(directory) / "Tiles.json"
             tiles_path.write_text("42", encoding="utf-8")
 
-            with self.assertRaisesRegex(ValueError, "tile database must be a JSON array"):
+            with self.assertRaisesRegex(
+                ValueError, "tile database must be a JSON array"
+            ):
                 generate_map(valid_recipe(), tiles_path)
 
     def test_output_filename_must_match_map_id(self):
@@ -455,7 +569,9 @@ class MapGeneratorTests(unittest.TestCase):
             recipe_path = Path(directory) / "recipe.json"
             recipe_path.write_text(json.dumps(valid_recipe()), encoding="utf-8")
 
-            with self.assertRaisesRegex(ValueError, "must be named generated_test_map.json"):
+            with self.assertRaisesRegex(
+                ValueError, "must be named generated_test_map.json"
+            ):
                 write_map(recipe_path, Path(directory) / "different.json", TILES_PATH)
 
     def test_write_map_protects_existing_output_unless_overwrite_is_enabled(self):


### PR DESCRIPTION
### Motivation
- Recipes should allow semantic palette references (e.g. "ground", "path") so designers can express variation without repeating raw tile IDs and to prepare for Phase 4B of the map generation roadmap.
- The generator already funnels tile handling through `_make_tile` and validation paths, so adding palette resolution is a small, backward-compatible extension that preserves `id`-based tiles and existing `null` empty-tile behavior.

### Description
- Add root-level `palette` support to the recipe schema and include `palette` in `RECIPE_FIELDS` so recipes can declare named weighted tile sets referenced by tile specs. 
- Introduce `PALETTE_FIELDS` and `PALETTE_NAME_PATTERN`, add `_validate_palette` and `_validate_palette_entry` to strictly validate palette shapes, names, entry fields, weights, rotations, and known tile IDs. 
- Extend `_validate_tile_spec` to allow tile specs to define exactly one of `id` or `palette` and to reject `rotation` when a palette name is used. 
- Implement `_select_weighted_palette_entry` and update `_make_tile` to deterministically resolve palette entries using the recipe `rng`, threading a validated `palette` context through placement functions (`_apply_set`, `_apply_rectangle`, `_apply_rectangle_outline`, `_apply_line`, `_apply_scatter`, legacy `regions`). 
- Update the example recipe `Tools/examples/map_recipe.json` and documentation `Documentation/Modding/map_recipe_generator.md` and `Documentation/Game_design/Map_generation_plan.md` to describe the new palette contract and RNG-consumption caveat. 
- Add focused tests to `Tools/tests/test_map_generator.py` to cover base-tile palette references, rectangle/scatter palette usage, weighted deterministic selection, malformed palette rejection, and ensure backwards compatibility with the example recipe.

### Testing
- Ran the unit test suite with `python3 -m unittest Tools.tests.test_map_generator Tools.tests.test_generate_map_examples`, which passed (38 tests).
- Generated and validated the updated example with `python3 Tools/map_generator.py Tools/examples/map_recipe.json /tmp/generated_meadow_prototype.json --overwrite` and `python3 Tools/map_validator.py /tmp/generated_meadow_prototype.json`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61de7dc7f48325b594f0f3bd3b9e04)